### PR TITLE
feat: Completed eventlistingcards

### DIFF
--- a/packages/onestop_ui/lib/components/cardcomponents/label.dart
+++ b/packages/onestop_ui/lib/components/cardcomponents/label.dart
@@ -18,10 +18,6 @@ class OCardLabels extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      padding: EdgeInsets.symmetric(
-        horizontal: OSpacing.xs,
-        vertical: OSpacing.xxs,
-      ),
       decoration: BoxDecoration(color: Colors.transparent),
       child: Row(
         mainAxisAlignment: MainAxisAlignment.center,
@@ -29,9 +25,9 @@ class OCardLabels extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.center,
         children: [
           Icon(icon, size: 16, color: color),
-          SizedBox(width: OSpacing.s),
+          SizedBox(width: OSpacing.xxs),
           OText(
-            text: label,
+            text: isSmall ? label.toUpperCase() : label,
             style:
                 isSmall
                     ? OTextStyle.labelXSmall.copyWith(color: color)

--- a/packages/onestop_ui/lib/components/cards/events_card.dart
+++ b/packages/onestop_ui/lib/components/cards/events_card.dart
@@ -243,6 +243,8 @@ class OEventCardCompact extends StatefulWidget {
   final String? tag1;
   final String? tag2;
   final String savedTime;
+  final Function(String feedback)?
+  onFeedbackSubmit; // Callback for feedback submission
 
   const OEventCardCompact({
     super.key,
@@ -253,6 +255,7 @@ class OEventCardCompact extends StatefulWidget {
     this.tag1,
     this.tag2,
     required this.savedTime,
+    this.onFeedbackSubmit,
   });
 
   @override
@@ -261,16 +264,36 @@ class OEventCardCompact extends StatefulWidget {
 
 class _OEventCardCompactState extends State<OEventCardCompact> {
   bool isPressed = false;
+  bool showFeedbackField = false;
+  bool feedbackSubmitted = false;
+  String submittedFeedback = '';
+  final TextEditingController _feedbackController = TextEditingController();
+
+  @override
+  void dispose() {
+    _feedbackController.dispose();
+    super.dispose();
+  }
+
+  void _handleFeedbackSubmit() {
+    if (_feedbackController.text.trim().isNotEmpty) {
+      setState(() {
+        submittedFeedback = _feedbackController.text.trim();
+        feedbackSubmitted = true;
+        showFeedbackField = false;
+      });
+
+      // Call the callback if provided
+      widget.onFeedbackSubmit?.call(submittedFeedback);
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
     return GestureDetector(
       behavior: HitTestBehavior.opaque,
       onTapDown:
-          (_) =>
-              widget.isEnabled
-                  ? setState(() => isPressed = true)
-                  : null, //engage behaviour when card is tapped
+          (_) => widget.isEnabled ? setState(() => isPressed = true) : null,
       onTapUp: (_) {
         setState(() => isPressed = false);
       },
@@ -366,22 +389,22 @@ class _OEventCardCompactState extends State<OEventCardCompact> {
                           ],
                         ),
                         const SizedBox(height: OSpacing.m),
-                          Row(
-                            children: [
-                              Icon(
-                                TablerIcons.file,
-                                size: 16,
+                        Row(
+                          children: [
+                            Icon(
+                              TablerIcons.file,
+                              size: 16,
+                              color: OColor.green600,
+                            ),
+                            const SizedBox(width: OSpacing.xxs),
+                            OText(
+                              text: "Saved ${widget.savedTime} ago",
+                              style: OTextStyle.labelXSmall.copyWith(
                                 color: OColor.green600,
                               ),
-                              const SizedBox(width: OSpacing.xxs),
-                              OText(
-                                text: "Saved ${widget.savedTime} ago",
-                                style: OTextStyle.labelXSmall.copyWith(
-                                  color: OColor.green600,
-                                ),
-                              ),
-                            ],
-                          ),
+                            ),
+                          ],
+                        ),
                       ],
                     ),
                   ],
@@ -398,54 +421,179 @@ class _OEventCardCompactState extends State<OEventCardCompact> {
               Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  OText(
-                    text: "Enjoyed the event?",
-                    style: OTextStyle.labelXSmall.copyWith(
-                      color:
-                          widget.isEnabled ? OColor.gray800 : OColor.green600,
-                    ),
-                  ),
-                  const SizedBox(height: OSpacing.xs),
-                  Container(
-                    padding: const EdgeInsets.symmetric(
-                      vertical: OSpacing.xs,
-                      horizontal: OSpacing.s,
-                    ),
-                    decoration: BoxDecoration(
-                      color: OColor.white,
-                      border: Border.all(color: OColor.gray400),
-                      borderRadius: BorderRadius.circular(OCornerRadius.l),
-                    ),
-                    child: GestureDetector(
-                      behavior: HitTestBehavior.opaque,
-                      onTap: () {},
-                      child: Center(
-                        child: Row(
-                          mainAxisAlignment: MainAxisAlignment.center,
+                  // Show submitted feedback message
+                  if (feedbackSubmitted)
+                    Divider(color: OColor.gray200),
+                    if (feedbackSubmitted)
+                    Container(
+                      padding: const EdgeInsets.all(OSpacing.s),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          OText(
+                            text: "YOUR FEEDBACK",
+                            style: OTextStyle.labelXSmall.copyWith(
+                              color: OColor.gray800,
+                            ),
+                          ),
+                          const SizedBox(height: OSpacing.xs),
+                          Row(
+                            children: [
+                              Icon(
+                                TablerIcons.message_heart,
+                                size: 16,
+                                color: OColor.green600,
+                              ),
+                              const SizedBox(width: OSpacing.xxs),
+                              OText(
+                                text: "\"$submittedFeedback\"",
+                                style: OTextStyle.bodySmall.copyWith(
+                                  color: OColor.gray600,
+                                ),
+                              ),
+                            ],
+                          ),
+                        ],
+                      ),
+                    )
+                  // Show feedback input field
+                  else if (showFeedbackField)
+                    Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        OTextField(
+                          label: "Leave A Feedback",
+                          controller: _feedbackController,
+                          isParagraph: true,
+                        ),
+                        const SizedBox(height: OSpacing.s),
+                        Row(
                           children: [
-                            OText(
-                              text: "Submit a Feedback",
-                              style: OTextStyle.labelSmall.copyWith(
-                                color:
-                                    widget.isEnabled
-                                        ? OColor.green600
-                                        : OColor.gray400,
+                            Expanded(
+                              child: GestureDetector(
+                                onTap: () {
+                                  setState(() {
+                                    showFeedbackField = false;
+                                    _feedbackController.clear();
+                                  });
+                                },
+                                child: Container(
+                                  padding: const EdgeInsets.symmetric(
+                                    vertical: OSpacing.xs,
+                                  ),
+                                  decoration: BoxDecoration(
+                                    color: OColor.white,
+                                    border: Border.all(color: OColor.gray400),
+                                    borderRadius: BorderRadius.circular(
+                                      OCornerRadius.l,
+                                    ),
+                                  ),
+                                  child: Center(
+                                    child: OText(
+                                      text: "Cancel",
+                                      style: OTextStyle.labelSmall.copyWith(
+                                        color: OColor.gray600,
+                                      ),
+                                    ),
+                                  ),
+                                ),
                               ),
                             ),
-                            const SizedBox(width: OSpacing.xs),
-                            Icon(
-                              TablerIcons.message_heart,
-                              color:
-                                  widget.isEnabled
-                                      ? OColor.green600
-                                      : OColor.gray400,
-                              size: 16,
+                            const SizedBox(width: OSpacing.s),
+                            Expanded(
+                              child: GestureDetector(
+                                onTap: _handleFeedbackSubmit,
+                                child: Container(
+                                  padding: const EdgeInsets.symmetric(
+                                    vertical: OSpacing.xs,
+                                  ),
+                                  decoration: BoxDecoration(
+                                    color: OColor.green600,
+                                    borderRadius: BorderRadius.circular(
+                                      OCornerRadius.l,
+                                    ),
+                                  ),
+                                  child: Center(
+                                    child: OText(
+                                      text: "Submit",
+                                      style: OTextStyle.labelSmall.copyWith(
+                                        color: OColor.white,
+                                      ),
+                                    ),
+                                  ),
+                                ),
+                              ),
                             ),
                           ],
                         ),
-                      ),
+                      ],
+                    )
+                  // Show initial feedback button
+                  else
+                    Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        OText(
+                          text: "Enjoyed the event?",
+                          style: OTextStyle.labelXSmall.copyWith(
+                            color:
+                                widget.isEnabled
+                                    ? OColor.gray800
+                                    : OColor.green600,
+                          ),
+                        ),
+                        const SizedBox(height: OSpacing.xs),
+                        GestureDetector(
+                          behavior: HitTestBehavior.opaque,
+                          onTap:
+                              widget.isEnabled
+                                  ? () {
+                                    setState(() {
+                                      showFeedbackField = true;
+                                    });
+                                  }
+                                  : null,
+                          child: Container(
+                            padding: const EdgeInsets.symmetric(
+                              vertical: OSpacing.xs,
+                              horizontal: OSpacing.s,
+                            ),
+                            decoration: BoxDecoration(
+                              color: OColor.white,
+                              border: Border.all(color: OColor.gray400),
+                              borderRadius: BorderRadius.circular(
+                                OCornerRadius.l,
+                              ),
+                            ),
+                            child: Center(
+                              child: Row(
+                                mainAxisAlignment: MainAxisAlignment.center,
+                                children: [
+                                  OText(
+                                    text: "Submit a Feedback",
+                                    style: OTextStyle.labelSmall.copyWith(
+                                      color:
+                                          widget.isEnabled
+                                              ? OColor.green600
+                                              : OColor.gray400,
+                                    ),
+                                  ),
+                                  const SizedBox(width: OSpacing.xs),
+                                  Icon(
+                                    TablerIcons.message_heart,
+                                    color:
+                                        widget.isEnabled
+                                            ? OColor.green600
+                                            : OColor.gray400,
+                                    size: 16,
+                                  ),
+                                ],
+                              ),
+                            ),
+                          ),
+                        ),
+                      ],
                     ),
-                  ),
                 ],
               ),
           ],

--- a/packages/onestop_ui/lib/components/cards/events_listing_cards.dart
+++ b/packages/onestop_ui/lib/components/cards/events_listing_cards.dart
@@ -4,88 +4,162 @@ import 'package:onestop_ui/index.dart';
 
 enum EventCardSize { small, medium, large }
 
-enum EventCardType { upcomingUser, pastUser, upcomingAdmin, pastAdmin }
+enum EventCardType { user, admin }
 
 class OEventListingCard extends StatefulWidget {
   final String title;
-  final String date;
+  final String? date;
   final EventCardSize size;
   final EventCardType type;
   final VoidCallback? onTap;
   final bool isDisabled;
+  final bool? isSaved;
+  final String? eventImageUrl;
+  final String startTime;
+  final String? endtime;
+  final String location;
+  final String? tag1;
+  final String? tag2;
+  final int? attendance;
+  final int? likes;
+  final int? views;
+  final int? feedbacks;
+  final IconData? tagIcon1;
+  final IconData? tagIcon2;
+  final String? hostImageUrl;
+  final String? hostName;
+  final VoidCallback? delete;
+  final VoidCallback? edit;
 
   const OEventListingCard._({
     super.key,
     required this.title,
-    required this.date,
+    this.date,
     required this.size,
     required this.type,
-    this.onTap,
+    required this.onTap,
+    this.eventImageUrl,
     this.isDisabled = false,
+    this.isSaved,
+    required this.startTime,
+    this.endtime,
+    required this.location,
+    this.tag1,
+    this.tag2,
+    this.attendance,
+    this.likes,
+    this.feedbacks,
+    this.views,
+    this.tagIcon1,
+    this.tagIcon2,
+    this.hostImageUrl,
+    this.hostName,
+    this.delete,
+    this.edit,
   });
-  const OEventListingCard.pastAdmin({
+  const OEventListingCard.small({
     Key? key,
     required String title,
-    required String date,
-    required EventCardSize size,
+    required String location,
+    required EventCardType type,
     VoidCallback? onTap,
     bool isDisabled = false,
+    required String startTime,
+    bool isSaved = false,
+    required String eventImageUrl,
+    String? tag1,
+    String? tag2,
   }) : this._(
          key: key,
          title: title,
-         date: date,
-         size: size,
-         type: EventCardType.pastAdmin,
+         location: location,
+         size: EventCardSize.small,
+         startTime: startTime,
+         type: type,
          onTap: onTap,
          isDisabled: isDisabled,
+         isSaved: isSaved,
+         eventImageUrl: eventImageUrl,
+         tag1: tag1,
+         tag2: tag2,
        );
-  const OEventListingCard.pastUser({
+  const OEventListingCard.medium({
     Key? key,
     required String title,
     required String date,
-    required EventCardSize size,
+    required String location,
+    required EventCardType type,
     VoidCallback? onTap,
     bool isDisabled = false,
+    required String startTime,
+    bool isSaved = false,
+    required String eventImageUrl,
+    int? attendance,
+    String? endtime,
   }) : this._(
          key: key,
          title: title,
          date: date,
-         size: size,
-         type: EventCardType.pastUser,
+         size: EventCardSize.medium,
+         location: location,
+         type: type,
          onTap: onTap,
          isDisabled: isDisabled,
+         startTime: startTime,
+         isSaved: isSaved,
+         eventImageUrl: eventImageUrl,
+         attendance: attendance,
+         endtime: endtime,
        );
-  const OEventListingCard.upcomingAdmin({
+  const OEventListingCard.large({
     Key? key,
     required String title,
     required String date,
-    required EventCardSize size,
+    required String location,
+    required EventCardType type,
     VoidCallback? onTap,
     bool isDisabled = false,
+    required String startTime,
+    bool isSaved = false,
+    required String eventImageUrl,
+    int? attendance,
+    int? likes,
+    int? views,
+    int? feedbacks,
+    String? tag1,
+    String? tag2,
+    IconData? tagIcon1,
+    IconData? tagIcon2,
+    String? hostImageUrl,
+    String? hostName,
+    VoidCallback? delete,
+    VoidCallback? edit,
+    String? endtime,
   }) : this._(
          key: key,
          title: title,
          date: date,
-         size: size,
-         type: EventCardType.upcomingAdmin,
+         size: EventCardSize.large,
+         startTime: startTime,
+         type: type,
+         location: location,
          onTap: onTap,
          isDisabled: isDisabled,
-       );
-  const OEventListingCard.upcomingUser({
-    Key? key,
-    required String title,
-    required String date,
-    required EventCardSize size,
-    VoidCallback? onTap,
-    bool isDisabled = false,
-  }) : this._(
-         key: key,
-         title: title,
-         date: date,
-         size: size,
-         type: EventCardType.upcomingUser,
-         onTap: onTap,
-         isDisabled: isDisabled,
+         isSaved: isSaved,
+         eventImageUrl: eventImageUrl,
+         attendance: attendance,
+         likes: likes,
+         views: views,
+         feedbacks: feedbacks,
+         tag2: tag2,
+         tag1: tag1,
+         delete: delete,
+         edit: edit,
+         tagIcon1: tagIcon1,
+         tagIcon2: tagIcon2,
+         endtime: endtime,
+         hostImageUrl: hostImageUrl,
+         hostName: hostName,
        );
 
   @override
@@ -94,7 +168,6 @@ class OEventListingCard extends StatefulWidget {
 
 class _OEventListingCardState extends State<OEventListingCard> {
   bool _isPressed = false;
-  bool _isSaved = false;
 
   @override
   void initState() {
@@ -105,13 +178,10 @@ class _OEventListingCardState extends State<OEventListingCard> {
   Widget build(BuildContext context) {
     return GestureDetector(
       behavior: HitTestBehavior.opaque,
-      onTapDown:
-          (_) =>
-              widget.isDisabled
-                  ? null
-                  : setState(
-                    () => _isPressed = true,
-                  ), //engage behaviour when card is tapped
+      onTapDown: (_) {
+        widget.isDisabled ? null : setState(() => _isPressed = true);
+        widget.isDisabled ? null : widget.onTap;
+      },
       onTapUp: (_) {
         setState(() => _isPressed = false);
       },
@@ -128,8 +198,8 @@ class _OEventListingCardState extends State<OEventListingCard> {
 
   Widget _buildCardContent() {
     // Build content based on size - larger cards show more info
-    if (widget.size == EventCardSize.small) {
-      return Padding(
+    return switch (widget.size) {
+      EventCardSize.small => Padding(
         padding: const EdgeInsets.all(OSpacing.s),
         child: Row(
           crossAxisAlignment: CrossAxisAlignment.center,
@@ -144,9 +214,7 @@ class _OEventListingCardState extends State<OEventListingCard> {
                     borderRadius: BorderRadius.circular(OCornerRadius.xl),
                     color: OColor.gray400,
                     image: DecorationImage(
-                      image: NetworkImage(
-                        "https://variety.com/wp-content/uploads/2019/10/shutterstock_editorial_10435445et.jpg?w=1000&h=667&crop=1",
-                      ),
+                      image: NetworkImage(widget.eventImageUrl!),
                       fit: BoxFit.cover,
                       opacity: 1,
                     ),
@@ -157,92 +225,84 @@ class _OEventListingCardState extends State<OEventListingCard> {
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
                     OText(
-                      text: "Event Title",
+                      text: widget.title,
                       style: OTextStyle.bodyMedium.copyWith(
                         color:
                             widget.isDisabled ? OColor.gray600 : OColor.gray800,
                       ),
                     ),
-                    if (_isSaved == true) const SizedBox(height: OSpacing.xxs),
-                    if (_isSaved == true)
-                      Row(
-                        children: [
-                          Icon(
-                            TablerIcons.check,
-                            size: 16,
-                            color:
-                                widget.isDisabled
-                                    ? OColor.gray400
-                                    : OColor.green600,
-                          ),
-                          const SizedBox(width: OSpacing.xxs),
-                          OText(
-                            text: "I'm going",
-                            style: OTextStyle.labelXSmall.copyWith(
-                              color:
-                                  widget.isDisabled
-                                      ? OColor.gray400
-                                      : OColor.green600,
-                            ),
-                          ),
-                        ],
+                    if (widget.isSaved == true)
+                      const SizedBox(height: OSpacing.xxs),
+                    if (widget.isSaved == true)
+                      OCardLabels(
+                        label: "I'm Going",
+                        icon: TablerIcons.check,
+                        color:
+                            widget.isDisabled
+                                ? OColor.gray400
+                                : OColor.green600,
                       ),
                     const SizedBox(height: OSpacing.xxs),
                     OText(
-                      text: "Time," + "Location",
+                      text: "${widget.startTime}, ${widget.location}",
                       style: OTextStyle.bodySmall.copyWith(
                         color:
                             widget.isDisabled ? OColor.gray400 : OColor.gray600,
                       ),
                     ),
-                    const SizedBox(height: OSpacing.xs),
-                    Row(
-                      children: [
-                        Container(
-                          width: 46,
-                          height: 24,
-                          decoration: BoxDecoration(
-                            color: OColor.gray100,
-                            borderRadius: BorderRadius.circular(
-                              OCornerRadius.xl,
-                            ),
-                          ),
-                          child: Center(
-                            child: OText(
-                              text: "TAg1",
-                              style: OTextStyle.labelXSmall.copyWith(
-                                color:
-                                    widget.isDisabled
-                                        ? OColor.gray400
-                                        : OColor.blue600,
+                    if (widget.tag1 != null && widget.tag2 != null)
+                      const SizedBox(height: OSpacing.xs),
+                    if (widget.tag1 != null && widget.tag2 != null)
+                      Row(
+                        children: [
+                          if (widget.tag1 != null)
+                            Container(
+                              width: 46,
+                              height: 24,
+                              decoration: BoxDecoration(
+                                color: OColor.gray100,
+                                borderRadius: BorderRadius.circular(
+                                  OCornerRadius.xl,
+                                ),
+                              ),
+                              child: Center(
+                                child: OText(
+                                  text: widget.tag1?.toUpperCase(),
+                                  style: OTextStyle.labelXSmall.copyWith(
+                                    color:
+                                        widget.isDisabled
+                                            ? OColor.gray400
+                                            : OColor.blue600,
+                                  ),
+                                ),
                               ),
                             ),
-                          ),
-                        ),
-                        const SizedBox(width: OSpacing.m),
-                        Container(
-                          width: 46,
-                          height: 24,
-                          decoration: BoxDecoration(
-                            color: OColor.gray100,
-                            borderRadius: BorderRadius.circular(
-                              OCornerRadius.xl,
-                            ),
-                          ),
-                          child: Center(
-                            child: OText(
-                              text: "TAg2",
-                              style: OTextStyle.labelXSmall.copyWith(
-                                color:
-                                    widget.isDisabled
-                                        ? OColor.gray400
-                                        : OColor.green600,
+                          if (widget.tag2 != null)
+                            const SizedBox(width: OSpacing.m),
+                          if (widget.tag2 != null)
+                            Container(
+                              width: 46,
+                              height: 24,
+                              decoration: BoxDecoration(
+                                color: OColor.gray100,
+                                borderRadius: BorderRadius.circular(
+                                  OCornerRadius.xl,
+                                ),
+                              ),
+                              child: Center(
+                                child: OText(
+                                  text: widget.tag2?.toUpperCase(),
+                                  style: OTextStyle.labelXSmall.copyWith(
+                                    color:
+                                        widget.isDisabled
+                                            ? OColor.gray400
+                                            : OColor.green600,
+                                  ),
+                                ),
                               ),
                             ),
-                          ),
-                        ),
-                      ],
-                    ),
+                        ],
+                      ),
                   ],
                 ),
               ],
@@ -254,10 +314,8 @@ class _OEventListingCardState extends State<OEventListingCard> {
             ),
           ],
         ),
-      );
-    }
-    if (widget.size == EventCardSize.medium) {
-      return Column(
+      ),
+      EventCardSize.medium => Column(
         children: [
           Container(
             width: 210,
@@ -269,9 +327,7 @@ class _OEventListingCardState extends State<OEventListingCard> {
               ),
               color: OColor.gray400,
               image: DecorationImage(
-                image: NetworkImage(
-                  "https://variety.com/wp-content/uploads/2019/10/shutterstock_editorial_10435445et.jpg?w=1000&h=667&crop=1",
-                ),
+                image: NetworkImage(widget.eventImageUrl!),
                 fit: BoxFit.cover,
                 opacity: 1,
               ),
@@ -292,55 +348,39 @@ class _OEventListingCardState extends State<OEventListingCard> {
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 OText(
-                  text: "Event Title",
+                  text: widget.title,
                   style: OTextStyle.bodyMedium.copyWith(
                     color: widget.isDisabled ? OColor.gray600 : OColor.gray800,
                   ),
                 ),
                 const SizedBox(width: OSpacing.xs),
                 OText(
-                  text: "Date," + " " + "Start time -" + " " + "End time",
+                  text:
+                      "${widget.date}, ${widget.startTime} - ${widget.endtime}",
                   style: OTextStyle.bodySmall.copyWith(
                     color: widget.isDisabled ? OColor.gray400 : OColor.gray600,
                   ),
                 ),
                 const SizedBox(width: OSpacing.xxs),
                 OText(
-                  text: "Location",
+                  text: widget.location,
                   style: OTextStyle.bodySmall.copyWith(
                     color: widget.isDisabled ? OColor.gray400 : OColor.gray600,
                   ),
                 ),
                 const SizedBox(width: OSpacing.xs),
-                if (_isSaved == true)
-                  Row(
-                    children: [
-                      Icon(
-                        TablerIcons.check,
-                        size: 16,
-                        color:
-                            widget.isDisabled
-                                ? OColor.gray400
-                                : OColor.green600,
-                      ),
-                      const SizedBox(width: OSpacing.xxs),
-                      OText(
-                        text: "Going",
-                        style: OTextStyle.labelXSmall.copyWith(
-                          color:
-                              widget.isDisabled
-                                  ? OColor.gray400
-                                  : OColor.green600,
-                        ),
-                      ),
-                    ],
+                if (widget.isSaved == true)
+                  OCardLabels(
+                    label: "Going",
+                    icon: TablerIcons.check,
+                    color: widget.isDisabled ? OColor.gray400 : OColor.green600,
                   ),
-                if (_isSaved != true)
+                if (widget.isSaved != true)
                   Row(
                     children: [
                       const SizedBox(width: OSpacing.m),
                       OText(
-                        text: "+ 350 Others",
+                        text: "+ ${widget.attendance} others",
                         style: OTextStyle.labelXSmall.copyWith(
                           color:
                               widget.isDisabled
@@ -354,221 +394,190 @@ class _OEventListingCardState extends State<OEventListingCard> {
             ),
           ),
         ],
-      );
-    }
-    return Padding(
-      padding: const EdgeInsets.all(OSpacing.s),
-      child: Column(
-        children: [
-          Container(
-            height: 187.53,
-            decoration: BoxDecoration(
-              borderRadius: BorderRadius.all(Radius.circular(OCornerRadius.s)),
-              color: OColor.gray400,
-              image: DecorationImage(
-                image: NetworkImage(
-                  "https://variety.com/wp-content/uploads/2019/10/shutterstock_editorial_10435445et.jpg?w=1000&h=667&crop=1",
+      ),
+      EventCardSize.large => Padding(
+        padding: const EdgeInsets.all(OSpacing.s),
+        child: Column(
+          children: [
+            Container(
+              height: 187.53,
+              decoration: BoxDecoration(
+                borderRadius: BorderRadius.all(
+                  Radius.circular(OCornerRadius.s),
                 ),
-                fit: BoxFit.cover,
-                opacity: 1,
+                color: OColor.gray400,
+                image: DecorationImage(
+                  image: NetworkImage(widget.eventImageUrl!),
+                  fit: BoxFit.cover,
+                  opacity: 1,
+                ),
               ),
             ),
-          ),
-          const SizedBox(height: OSpacing.s),
-          Row(
-            children: [
+            if (widget.type == EventCardType.admin)
+              const SizedBox(height: OSpacing.s),
+            if (widget.type == EventCardType.admin)
               Row(
+                mainAxisAlignment: MainAxisAlignment.start,
                 children: [
-                  Icon(
-                    TablerIcons.heart_plus,
-                    size: 16,
+                  OCardLabels(
+                    label: widget.likes.toString(),
+                    icon: TablerIcons.heart_plus,
                     color: widget.isDisabled ? OColor.gray400 : OColor.blue500,
+                    isSmall: true,
                   ),
-                  const SizedBox(width: OSpacing.xxs),
-                  OText(
-                    text: "350",
-                    style: OTextStyle.labelXSmall.copyWith(
-                      color:
-                          widget.isDisabled ? OColor.gray400 : OColor.blue500,
-                    ),
+                  const SizedBox(width: OSpacing.s),
+                  OCardLabels(
+                    label: widget.views.toString(),
+                    icon: TablerIcons.eye,
+                    color: widget.isDisabled ? OColor.gray400 : OColor.blue500,
+                    isSmall: true,
+                  ),
+                  const SizedBox(width: OSpacing.s),
+                  OCardLabels(
+                    label: widget.feedbacks.toString(),
+                    icon: TablerIcons.message_heart,
+                    color: widget.isDisabled ? OColor.gray400 : OColor.blue500,
+                    isSmall: true,
                   ),
                 ],
               ),
-              const SizedBox(width: OSpacing.s),
-              Row(
-                children: [
-                  Icon(
-                    TablerIcons.eye,
-                    size: 16,
-                    color: widget.isDisabled ? OColor.gray400 : OColor.blue500,
+            const SizedBox(height: OSpacing.s),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                OText(
+                  text: widget.title,
+                  style: OTextStyle.headingSmall.copyWith(
+                    color: widget.isDisabled ? OColor.gray600 : OColor.gray800,
                   ),
-                  const SizedBox(width: OSpacing.xxs),
-                  OText(
-                    text: "800",
-                    style: OTextStyle.labelXSmall.copyWith(
-                      color:
-                          widget.isDisabled ? OColor.gray400 : OColor.blue500,
-                    ),
-                  ),
-                ],
-              ),
-              const SizedBox(width: OSpacing.s),
-              Row(
-                children: [
-                  Icon(
-                    TablerIcons.message_heart,
-                    size: 16,
-                    color: widget.isDisabled ? OColor.gray400 : OColor.blue500,
-                  ),
-                  const SizedBox(width: OSpacing.xxs),
-                  OText(
-                    text: "350",
-                    style: OTextStyle.labelXSmall.copyWith(
-                      color:
-                          widget.isDisabled ? OColor.gray400 : OColor.blue500,
-                    ),
-                  ),
-                ],
-              ),
-            ],
-          ),
-          const SizedBox(height: OSpacing.s),
-          Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
-              OText(
-                text: "Event Title",
-                style: OTextStyle.headingSmall.copyWith(
-                  color: widget.isDisabled ? OColor.gray600 : OColor.gray800,
                 ),
-              ),
-              Icon(
-                TablerIcons.chevron_right,
-                color: widget.isDisabled ? OColor.gray400 : OColor.gray600,
-                size: 24,
-              ),
-            ],
-          ),
-          const SizedBox(height: OSpacing.s),
-          Row(
-            children: [
-              Container(
-                width: 46,
-                height: 24,
-                decoration: BoxDecoration(
-                  color: OColor.gray100,
-                  borderRadius: BorderRadius.circular(OCornerRadius.xl),
+                Icon(
+                  TablerIcons.chevron_right,
+                  color: widget.isDisabled ? OColor.gray400 : OColor.gray600,
+                  size: 24,
                 ),
-                child: Center(
-                  child: OText(
-                    text: "TAg1",
-                    style: OTextStyle.labelXSmall.copyWith(
+              ],
+            ),
+            const SizedBox(height: OSpacing.s),
+            Row(
+              children: [
+                Container(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: OSpacing.xs,
+                    vertical: OSpacing.xxs,
+                  ),
+                  decoration: BoxDecoration(
+                    color: OColor.gray100,
+                    borderRadius: BorderRadius.circular(OCornerRadius.xl),
+                  ),
+                  child: Center(
+                    child: OCardLabels(
+                      label: widget.tag1!.toUpperCase(),
+                      icon: widget.tagIcon1!,
                       color:
                           widget.isDisabled ? OColor.gray400 : OColor.blue600,
                     ),
                   ),
                 ),
-              ),
-              const SizedBox(width: OSpacing.m),
-              Container(
-                width: 46,
-                height: 24,
-                decoration: BoxDecoration(
-                  color: OColor.gray100,
-                  borderRadius: BorderRadius.circular(OCornerRadius.xl),
-                ),
-                child: Center(
-                  child: OText(
-                    text: "TAg2",
-                    style: OTextStyle.labelXSmall.copyWith(
+                const SizedBox(width: OSpacing.m),
+                Container(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: OSpacing.xs,
+                    vertical: OSpacing.xxs,
+                  ),
+                  decoration: BoxDecoration(
+                    color: OColor.gray100,
+                    borderRadius: BorderRadius.circular(OCornerRadius.xl),
+                  ),
+                  child: Center(
+                    child: OCardLabels(
+                      label: widget.tag2!.toUpperCase(),
+                      icon: widget.tagIcon2!,
                       color:
                           widget.isDisabled ? OColor.gray400 : OColor.green600,
                     ),
                   ),
                 ),
-              ),
-            ],
-          ),
-          const SizedBox(height: OSpacing.s),
-          Column(
-            children: [
-              Row(
-                children: [
-                  Icon(
-                    TablerIcons.map_pin,
-                    color: widget.isDisabled ? OColor.gray400 : OColor.gray600,
-                    size: 16,
-                  ),
-                  const SizedBox(width: OSpacing.xxs),
-                  OText(
-                    text: "Location",
-                    style: OTextStyle.labelSmall.copyWith(
+              ],
+            ),
+            const SizedBox(height: OSpacing.s),
+            Column(
+              children: [
+                Row(
+                  children: [
+                    Icon(
+                      TablerIcons.map_pin,
                       color:
                           widget.isDisabled ? OColor.gray400 : OColor.gray600,
+                      size: 16,
                     ),
-                  ),
-                ],
-              ),
-              const SizedBox(height: OSpacing.xxs),
-              Row(
-                children: [
-                  Icon(
-                    TablerIcons.calendar,
-                    color: widget.isDisabled ? OColor.gray400 : OColor.gray600,
-                    size: 16,
-                  ),
-                  const SizedBox(width: OSpacing.xxs),
-                  OText(
-                    text: "Date," + " " + "Start time -" + " " + "End time",
-                    style: OTextStyle.labelSmall.copyWith(
+                    const SizedBox(width: OSpacing.xxs),
+                    OText(
+                      text: widget.location,
+                      style: OTextStyle.labelSmall.copyWith(
+                        color:
+                            widget.isDisabled ? OColor.gray400 : OColor.gray600,
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: OSpacing.xxs),
+                Row(
+                  children: [
+                    Icon(
+                      TablerIcons.calendar,
                       color:
                           widget.isDisabled ? OColor.gray400 : OColor.gray600,
+                      size: 16,
+                    ),
+                    const SizedBox(width: OSpacing.xxs),
+                    OText(
+                      text:
+                          "${widget.date}, ${widget.startTime} - ${widget.endtime}",
+                      style: OTextStyle.labelSmall.copyWith(
+                        color:
+                            widget.isDisabled ? OColor.gray400 : OColor.gray600,
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+            const SizedBox(height: OSpacing.s),
+            Row(
+              children: [
+                Container(
+                  width: 24,
+                  height: 24,
+                  decoration: BoxDecoration(
+                    borderRadius: BorderRadius.circular(OCornerRadius.xl),
+                    color: OColor.gray400,
+                    image: DecorationImage(
+                      image: NetworkImage(widget.hostImageUrl!),
+                      fit: BoxFit.cover,
+                      opacity: 1,
                     ),
                   ),
-                ],
-              ),
-            ],
-          ),
-          const SizedBox(height: OSpacing.s),
-          Row(
-            children: [
-              Container(
-                width: 24,
-                height: 24,
-                decoration: BoxDecoration(
-                  borderRadius: BorderRadius.circular(OCornerRadius.xl),
-                  color: OColor.gray400,
-                  image: DecorationImage(
-                    image: NetworkImage(
-                      "https://variety.com/wp-content/uploads/2019/10/shutterstock_editorial_10435445et.jpg?w=1000&h=667&crop=1",
-                    ),
-                    fit: BoxFit.cover,
-                    opacity: 1,
+                ),
+                const SizedBox(width: OSpacing.xs),
+                OText(
+                  text: widget.hostName!,
+                  style: OTextStyle.labelSmall.copyWith(
+                    color: widget.isDisabled ? OColor.gray600 : OColor.gray600,
                   ),
                 ),
-              ),
-              const SizedBox(width: OSpacing.xs),
-              OText(
-                text: "Student's Web Committee",
-                style: OTextStyle.labelSmall.copyWith(
-                  color: widget.isDisabled ? OColor.gray600 : OColor.gray600,
-                ),
-              ),
-            ],
-          ),
-          _buildTypeSpecificContent(),
-        ],
+              ],
+            ),
+            _buildTypeSpecificContent(),
+          ],
+        ),
       ),
-    );
+    };
   }
 
   Widget _buildTypeSpecificContent() {
     return switch (widget.type) {
-      EventCardType.upcomingUser => Row(
-        children: [
-        ],
-      ),
-      EventCardType.pastUser => Column(
+      EventCardType.user => Column(
         children: [
           const SizedBox(height: OSpacing.s),
           Divider(color: OColor.gray200),
@@ -576,9 +585,9 @@ class _OEventListingCardState extends State<OEventListingCard> {
           Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
-              const SizedBox(width: OSpacing.m),
+              const SizedBox(width: OSpacing.xxs),
               OText(
-                text: "+ 350 Others",
+                text: "+ ${widget.attendance}",
                 style: OTextStyle.labelXSmall.copyWith(
                   color: widget.isDisabled ? OColor.gray400 : OColor.blue600,
                 ),
@@ -600,25 +609,10 @@ class _OEventListingCardState extends State<OEventListingCard> {
                   behavior: HitTestBehavior.opaque,
                   onTap: () {},
                   child: Center(
-                    child: Row(
-                      children: [
-                        Icon(
-                          TablerIcons.heart,
-                          color:
-                              widget.isDisabled ? OColor.gray400 : OColor.white,
-                          size: 16,
-                        ),
-                        const SizedBox(width: OSpacing.xs),
-                        OText(
-                          text: "I'm Going",
-                          style: OTextStyle.labelSmall.copyWith(
-                            color:
-                                widget.isDisabled
-                                    ? OColor.gray400
-                                    : OColor.white,
-                          ),
-                        ),
-                      ],
+                    child: OCardLabels(
+                      label: "I'm Going",
+                      icon: TablerIcons.heart,
+                      color: widget.isDisabled ? OColor.gray400 : OColor.white,
                     ),
                   ),
                 ),
@@ -627,7 +621,7 @@ class _OEventListingCardState extends State<OEventListingCard> {
           ),
         ],
       ),
-      EventCardType.upcomingAdmin => Column(
+      EventCardType.admin => Column(
         children: [
           const SizedBox(height: OSpacing.xs),
           Divider(color: OColor.gray200),
@@ -636,7 +630,7 @@ class _OEventListingCardState extends State<OEventListingCard> {
             mainAxisAlignment: MainAxisAlignment.spaceAround,
             children: [
               TextButton.icon(
-                onPressed: () {}, //widget.edit,
+                onPressed: widget.edit,
                 icon: Icon(
                   TablerIcons.edit,
                   size: 16,
@@ -650,7 +644,7 @@ class _OEventListingCardState extends State<OEventListingCard> {
                 ),
               ),
               TextButton.icon(
-                onPressed: () {}, // widget.delete,
+                onPressed: widget.delete,
                 icon: Icon(
                   TablerIcons.trash,
                   size: 16,
@@ -667,12 +661,11 @@ class _OEventListingCardState extends State<OEventListingCard> {
           ),
         ],
       ),
-      EventCardType.pastAdmin => Row(children: []),
     };
   }
 
-  @ override
-  void dispose(){
+  @override
+  void dispose() {
     super.dispose();
   }
 }

--- a/packages/onestop_ui/lib/components/cards/events_listing_cards.dart
+++ b/packages/onestop_ui/lib/components/cards/events_listing_cards.dart
@@ -14,6 +14,7 @@ class OEventListingCard extends StatefulWidget {
   final VoidCallback? onTap;
   final bool isDisabled;
   final bool? isSaved;
+  final bool? isEditable;
   final String? eventImageUrl;
   final String startTime;
   final String? endtime;
@@ -55,7 +56,7 @@ class OEventListingCard extends StatefulWidget {
     this.hostImageUrl,
     this.hostName,
     this.delete,
-    this.edit,
+    this.edit, this.isEditable,
   });
   const OEventListingCard.small({
     Key? key,
@@ -121,6 +122,7 @@ class OEventListingCard extends StatefulWidget {
     bool isDisabled = false,
     required String startTime,
     bool isSaved = false,
+    bool isEditable = false,
     required String eventImageUrl,
     int? attendance,
     int? likes,
@@ -146,6 +148,7 @@ class OEventListingCard extends StatefulWidget {
          onTap: onTap,
          isDisabled: isDisabled,
          isSaved: isSaved,
+         isEditable: isEditable,
          eventImageUrl: eventImageUrl,
          attendance: attendance,
          likes: likes,
@@ -179,8 +182,10 @@ class _OEventListingCardState extends State<OEventListingCard> {
     return GestureDetector(
       behavior: HitTestBehavior.opaque,
       onTapDown: (_) {
-        widget.isDisabled ? null : setState(() => _isPressed = true);
-        widget.isDisabled ? null : widget.onTap;
+        if (!widget.isDisabled) {
+          setState(() => _isPressed = true);
+          widget.onTap?.call();
+        }
       },
       onTapUp: (_) {
         setState(() => _isPressed = false);
@@ -623,9 +628,13 @@ class _OEventListingCardState extends State<OEventListingCard> {
       ),
       EventCardType.admin => Column(
         children: [
+          if(widget.isEditable == true)
           const SizedBox(height: OSpacing.xs),
+          if(widget.isEditable == true)
           Divider(color: OColor.gray200),
+          if(widget.isEditable == true)
           const SizedBox(height: OSpacing.xs),
+          if(widget.isEditable == true)
           Row(
             mainAxisAlignment: MainAxisAlignment.spaceAround,
             children: [

--- a/packages/onestop_ui/lib/widget_demo/cards_demo.dart
+++ b/packages/onestop_ui/lib/widget_demo/cards_demo.dart
@@ -30,88 +30,134 @@ class CardsDemo extends StatelessWidget {
             savedTime: '30 min',
           ),
           const SizedBox(height: OSpacing.s),
-          OEventListingCard.pastAdmin(
+          OEventListingCard.large(
             title: "Flutter Workshop",
             date: "Nov 1, 2025",
-            size: EventCardSize.large,
+            type: EventCardType.user,
             onTap: () {},
-          ),
-          const SizedBox(height: OSpacing.s),
-          OEventListingCard.pastAdmin(
-            title: "Flutter Workshop",
-            date: "Nov 1, 2025",
-            size: EventCardSize.medium,
+            eventImageUrl:
+                "https://variety.com/wp-content/uploads/2019/10/shutterstock_editorial_10435445et.jpg?w=1000&h=667&crop=1",
+            location: '5G2',
+            startTime: '6:00 pm',
+            tag1: "TAG 1",
+            tag2: "TAG 2",
+            isSaved: true,
             isDisabled: true,
+            delete: (){},
+            edit: (){},
+            attendance: 350,
+            endtime: "8:00 pm",
+            feedbacks: 35,
+            views: 850,
+            likes: 350,tagIcon1:TablerIcons
+              .arrow_rotary_first_left ,
+            tagIcon2: TablerIcons
+                .arrow_rotary_first_left,
+            hostImageUrl: "https://variety.com/wp-content/uploads/2019/10/shutterstock_editorial_10435445et.jpg?w=1000&h=667&crop=1",
+              hostName: "SWC IITG",
           ),
           const SizedBox(height: OSpacing.s),
-          OEventListingCard.pastAdmin(
+          OEventListingCard.large(
             title: "Flutter Workshop",
             date: "Nov 1, 2025",
-            size: EventCardSize.small,
-            onTap: () => {},
-          ),
-          const SizedBox(height: OSpacing.s),
-          OEventListingCard.pastUser(
-            title: "Sports Day",
-            date: "Oct 15, 2025",
-            size: EventCardSize.large,
+            type: EventCardType.admin,
+            eventImageUrl:
+                "https://variety.com/wp-content/uploads/2019/10/shutterstock_editorial_10435445et.jpg?w=1000&h=667&crop=1",
             isDisabled: false,
+            location: '5G2',
+            startTime: '6:00 pm',
+            tag1: "TAG 1",
+            tag2: "TAG 2",
+            isSaved: false,
+            delete: (){},
+            edit: (){},
+            attendance: 350,
+            endtime: "8:00 pm",
+            feedbacks: 35,
+            views: 850,
+            likes: 350,tagIcon1:TablerIcons
+              .arrow_rotary_first_left ,
+            tagIcon2: TablerIcons
+                .arrow_rotary_first_left,
+            hostImageUrl: "https://variety.com/wp-content/uploads/2019/10/shutterstock_editorial_10435445et.jpg?w=1000&h=667&crop=1",
+            hostName: "SWC IITG",
           ),
           const SizedBox(height: OSpacing.s),
-          OEventListingCard.pastUser(
+          OEventListingCard.medium(
+            title: "Flutter Workshop",
+            date: "Nov 1, 2025",
+            type: EventCardType.user,
+            eventImageUrl:
+                "https://variety.com/wp-content/uploads/2019/10/shutterstock_editorial_10435445et.jpg?w=1000&h=667&crop=1",
+            location: '5G2',
+            startTime: '6:00 pm',
+            isSaved: true,
+            attendance: 350,
+            endtime: "8:00 pm",
+
+          ),
+          const SizedBox(height: OSpacing.s),
+          OEventListingCard.medium(
             title: "Sports Day",
             date: "Oct 15, 2025",
-            size: EventCardSize.medium,
-            onTap: () {},
+            type: EventCardType.user,
+            eventImageUrl:
+                "https://variety.com/wp-content/uploads/2019/10/shutterstock_editorial_10435445et.jpg?w=1000&h=667&crop=1",
+            isDisabled: true,
+            location: '5G2',
+            startTime: '6:00 pm',
+            attendance: 350,
+            endtime: "8:00 pm",
           ),
           const SizedBox(height: OSpacing.s),
-          OEventListingCard.pastUser(
+          OEventListingCard.small(
             title: "Sports Day",
-            date: "Oct 15, 2025",
-            size: EventCardSize.small,
+            type: EventCardType.user,
+            eventImageUrl:
+                "https://variety.com/wp-content/uploads/2019/10/shutterstock_editorial_10435445et.jpg?w=1000&h=667&crop=1",
             onTap: () {},
+            location: '5G2',
+            tag1: "TAG 1",
+            tag2: "TAG 2",
+            startTime: '6:00 pm',
+
           ),
           const SizedBox(height: OSpacing.s),
-          OEventListingCard.upcomingAdmin(
-            title: "Orientation",
-            date: "Dec 5, 2025",
-            size: EventCardSize.large,
+          OEventListingCard.small(
             isDisabled: true,
-          ),
-          const SizedBox(height: OSpacing.s),
-          OEventListingCard.upcomingAdmin(
-            title: "Orientation",
-            date: "Dec 5, 2025",
-            size: EventCardSize.medium,
+            isSaved: true,
+            title: "Sports Day",
+            type: EventCardType.user,
+            tag1: "TAG 1",
+            tag2: "TAG 2",
             onTap: () {},
+            eventImageUrl:
+                "https://variety.com/wp-content/uploads/2019/10/shutterstock_editorial_10435445et.jpg?w=1000&h=667&crop=1",
+            location: '5G2',
+            startTime: '6:00 pm',
           ),
           const SizedBox(height: OSpacing.s),
-          OEventListingCard.upcomingAdmin(
-            title: "Orientation",
-            date: "Dec 5, 2025",
-            size: EventCardSize.small,
+          OEventListingCard.small(
+            isDisabled: false,
+            isSaved: true,
+            title: "Sports Day",
+            type: EventCardType.user,
+            eventImageUrl:
+                "https://variety.com/wp-content/uploads/2019/10/shutterstock_editorial_10435445et.jpg?w=1000&h=667&crop=1",
             onTap: () {},
+            location: '5G2',
+            startTime: '6:00 pm',
           ),
           const SizedBox(height: OSpacing.s),
-          OEventListingCard.upcomingUser(
-            title: "Orientation",
-            date: "Dec 5, 2025",
-            size: EventCardSize.large,
-            onTap: () {},
-          ),
-          const SizedBox(height: OSpacing.s),
-          OEventListingCard.upcomingUser(
-            title: "Orientation",
-            date: "Dec 5, 2025",
-            size: EventCardSize.medium,
+          OEventListingCard.small(
+            title: "Sports Day",
+            type: EventCardType.user,
             isDisabled: true,
-          ),
-          const SizedBox(height: OSpacing.s),
-          OEventListingCard.upcomingUser(
-            title: "Orientation",
-            date: "Dec 5, 2025",
-            size: EventCardSize.small,
+            eventImageUrl:
+                "https://variety.com/wp-content/uploads/2019/10/shutterstock_editorial_10435445et.jpg?w=1000&h=667&crop=1",
             onTap: () {},
+            location: '5G2',
+            startTime: '6:00 pm',
           ),
           OHomeCardLarge(
             dataMap: {

--- a/packages/onestop_ui/lib/widget_demo/cards_demo.dart
+++ b/packages/onestop_ui/lib/widget_demo/cards_demo.dart
@@ -18,10 +18,21 @@ class CardsDemo extends StatelessWidget {
             tag1: "TAG 1",
             tag2: "TAG 2",
             savedTime: '30 min',
+            onFeedbackSubmit: (feedback) {},
           ),
           const SizedBox(height: OSpacing.s),
           OEventCardCompact(
             isEnabled: false,
+            isFeedbackOn: true,
+            title: 'Card header',
+            subText: 'Sub-text',
+            tag1: "TAG 1",
+            tag2: "TAG 2",
+            savedTime: '30 min',
+          ),
+          const SizedBox(height: OSpacing.s),
+          OEventCardCompact(
+            isEnabled: true,
             isFeedbackOn: false,
             title: 'Card Header',
             subText: 'Sub-text',
@@ -36,24 +47,24 @@ class CardsDemo extends StatelessWidget {
             type: EventCardType.admin,
             onTap: () {},
             eventImageUrl:
-            "https://variety.com/wp-content/uploads/2019/10/shutterstock_editorial_10435445et.jpg?w=1000&h=667&crop=1",
+                "https://variety.com/wp-content/uploads/2019/10/shutterstock_editorial_10435445et.jpg?w=1000&h=667&crop=1",
             location: '5G2',
             startTime: '6:00 pm',
             tag1: "TAG 1",
             tag2: "TAG 2",
             isSaved: true,
             isEditable: true,
-            delete: (){},
-            edit: (){},
+            delete: () {},
+            edit: () {},
             attendance: 350,
             endtime: "8:00 pm",
             feedbacks: 35,
             views: 850,
-            likes: 350,tagIcon1:TablerIcons
-              .arrow_rotary_first_left ,
-            tagIcon2: TablerIcons
-                .arrow_rotary_first_left,
-            hostImageUrl: "https://variety.com/wp-content/uploads/2019/10/shutterstock_editorial_10435445et.jpg?w=1000&h=667&crop=1",
+            likes: 350,
+            tagIcon1: TablerIcons.arrow_rotary_first_left,
+            tagIcon2: TablerIcons.arrow_rotary_first_left,
+            hostImageUrl:
+                "https://variety.com/wp-content/uploads/2019/10/shutterstock_editorial_10435445et.jpg?w=1000&h=667&crop=1",
             hostName: "SWC IITG",
           ),
           OEventListingCard.large(
@@ -69,18 +80,18 @@ class CardsDemo extends StatelessWidget {
             tag2: "TAG 2",
             isSaved: true,
             isDisabled: true,
-            delete: (){},
-            edit: (){},
+            delete: () {},
+            edit: () {},
             attendance: 350,
             endtime: "8:00 pm",
             feedbacks: 35,
             views: 850,
-            likes: 350,tagIcon1:TablerIcons
-              .arrow_rotary_first_left ,
-            tagIcon2: TablerIcons
-                .arrow_rotary_first_left,
-            hostImageUrl: "https://variety.com/wp-content/uploads/2019/10/shutterstock_editorial_10435445et.jpg?w=1000&h=667&crop=1",
-              hostName: "SWC IITG",
+            likes: 350,
+            tagIcon1: TablerIcons.arrow_rotary_first_left,
+            tagIcon2: TablerIcons.arrow_rotary_first_left,
+            hostImageUrl:
+                "https://variety.com/wp-content/uploads/2019/10/shutterstock_editorial_10435445et.jpg?w=1000&h=667&crop=1",
+            hostName: "SWC IITG",
           ),
           const SizedBox(height: OSpacing.s),
           OEventListingCard.large(
@@ -95,17 +106,17 @@ class CardsDemo extends StatelessWidget {
             tag1: "TAG 1",
             tag2: "TAG 2",
             isSaved: false,
-            delete: (){},
-            edit: (){},
+            delete: () {},
+            edit: () {},
             attendance: 350,
             endtime: "8:00 pm",
             feedbacks: 35,
             views: 850,
-            likes: 350,tagIcon1:TablerIcons
-              .arrow_rotary_first_left ,
-            tagIcon2: TablerIcons
-                .arrow_rotary_first_left,
-            hostImageUrl: "https://variety.com/wp-content/uploads/2019/10/shutterstock_editorial_10435445et.jpg?w=1000&h=667&crop=1",
+            likes: 350,
+            tagIcon1: TablerIcons.arrow_rotary_first_left,
+            tagIcon2: TablerIcons.arrow_rotary_first_left,
+            hostImageUrl:
+                "https://variety.com/wp-content/uploads/2019/10/shutterstock_editorial_10435445et.jpg?w=1000&h=667&crop=1",
             hostName: "SWC IITG",
           ),
           const SizedBox(height: OSpacing.s),
@@ -120,7 +131,6 @@ class CardsDemo extends StatelessWidget {
             isSaved: true,
             attendance: 350,
             endtime: "8:00 pm",
-
           ),
           const SizedBox(height: OSpacing.s),
           OEventListingCard.medium(
@@ -146,7 +156,6 @@ class CardsDemo extends StatelessWidget {
             tag1: "TAG 1",
             tag2: "TAG 2",
             startTime: '6:00 pm',
-
           ),
           const SizedBox(height: OSpacing.s),
           OEventListingCard.small(

--- a/packages/onestop_ui/lib/widget_demo/cards_demo.dart
+++ b/packages/onestop_ui/lib/widget_demo/cards_demo.dart
@@ -33,6 +33,32 @@ class CardsDemo extends StatelessWidget {
           OEventListingCard.large(
             title: "Flutter Workshop",
             date: "Nov 1, 2025",
+            type: EventCardType.admin,
+            onTap: () {},
+            eventImageUrl:
+            "https://variety.com/wp-content/uploads/2019/10/shutterstock_editorial_10435445et.jpg?w=1000&h=667&crop=1",
+            location: '5G2',
+            startTime: '6:00 pm',
+            tag1: "TAG 1",
+            tag2: "TAG 2",
+            isSaved: true,
+            isEditable: true,
+            delete: (){},
+            edit: (){},
+            attendance: 350,
+            endtime: "8:00 pm",
+            feedbacks: 35,
+            views: 850,
+            likes: 350,tagIcon1:TablerIcons
+              .arrow_rotary_first_left ,
+            tagIcon2: TablerIcons
+                .arrow_rotary_first_left,
+            hostImageUrl: "https://variety.com/wp-content/uploads/2019/10/shutterstock_editorial_10435445et.jpg?w=1000&h=667&crop=1",
+            hostName: "SWC IITG",
+          ),
+          OEventListingCard.large(
+            title: "Flutter Workshop",
+            date: "Nov 1, 2025",
             type: EventCardType.user,
             onTap: () {},
             eventImageUrl:


### PR DESCRIPTION
## **User description**
Added all the event listing cards i.e. OEventListingCard - S/M/L with user and admin variants.
OEventListingCard contains 3 named contructors i.e.  .small, .medium and .large while .large has further two fronts - user and admin.


___

## **CodeAnt-AI Description**
**Add full event listing cards with images, tags, attendance and admin actions**

### What Changed
- Replaced older past/upcoming variants with three explicit sizes (small, medium, large) and two roles (user, admin); demo updated to use the new constructors
- Cards now accept and display event image, start/end times, location, host picture/name, tag pills, and numeric metrics (attendance, likes, views, feedbacks)
- User-mode cards show attendance counts and a saved/"I'm Going" indicator; saved state renders a check label
- Admin-mode cards surface summary labels (likes, views, feedbacks) and include Edit and Delete buttons wired to provided callbacks
- Tag labels are shown as compact pill labels (uppercased for small variants); disabled cards render muted colors and pressed taps show a pressed state visual
- Demo snippets updated with sample images, tags, host info and action handlers so cards render realistic content

### Impact
`✅ Clearer event previews with images and host info`
`✅ Easier event management for admins via in-card Edit/Delete`
`✅ Clearer attendance and saved state for users`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
