### PR TITLE
feat: Added travel cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,17 +6,20 @@ This library provides all the necessary UI components for the development of mai
 All the UI components are actively developed and being pushed to dev branch so kindly keep your forks updated with dev branch of this library
 currently following components are ready for being used and pushed to dev branch -
 - Theme - OColors, OText, OTextStyles, OCornerRadius, OSpacing, and other base constants
-- Indicators - Banners, Status, Avatar, Badges , Tags, Progress indicator
+- Indicators - Banners, Status, Avatar, Badges , Tags, Progress indicator, SnackBars
 - List Tiles
 - Text fields - OTextField , OSearchBar
+- Date and Time inputs
 - Buttons - PrimaryButton, SecondaryButton, TertiaryButton, CircularButton, RadioButton, IconButton, ToggleButton
-- Cards - OHomeCard (small), OMessMenuCard, FoodOutletCard, OCabSharingCard, OEventCard, OProductListingCard, OProductRequestCard, OLostFoundCard, OHomeCardLarge, OModalBasic, OFoodModal, OModalSecondary
+- Cards - OHomeCard (small), OMessMenuCard, FoodOutletCard, OCabSharingCard, OEventCard, OProductListingCard, OProductRequestCard, OLostFoundCard, OHomeCardLarge, OModalBasic, OFoodModal, OModalSecondary, OTravelCard, OTravelSuggestionCard, OEventCardCompact, OEventListingCard -S/M/L
+- Image previews and Image Gallery
 
 ## Additional Info
 - Please go through the repo first and always refer dev branch for latest updates.
 - For demo of each widget run the main.dart in dev
 - For additional info on each card usage go through the widget_demo directory in packages/onestop_ui/lib/widget_demo
 - Please refer comments available (if any) and use ctrl + click on each widget to navigate to it's definition.
+- Always raise PR in dev branch of repo for more info read CONTRIBUTING.md.
 
 ## Need Help?
 If you experience any issue in this repo or require some other component please raise an issue or contact us we will try to address it as soon as possible.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:onestop_ui/components/ListButtons/ToggleButton.dart';
 import 'package:onestop_ui/index.dart';
 
 void main() async {
@@ -37,11 +36,6 @@ class _MyAppState extends State<MyApp> {
   }
   @override
   Widget build(BuildContext context) {
-    final List<String> demoImages = [
-      'https://picsum.photos/400/200?image=1',
-      'https://picsum.photos/400/200?image=2',
-      'https://picsum.photos/400/200?image=3',
-    ];
     return MaterialApp(
       title: 'OneStop UI Demo',
       debugShowCheckedModeBanner: false,

--- a/packages/onestop_ui/lib/components/ListButtons/toggle_button.dart
+++ b/packages/onestop_ui/lib/components/ListButtons/toggle_button.dart
@@ -1,9 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:onestop_ui/index.dart';
-import '../../constants/spacing.dart';
-import '../../constants/corner_radius.dart';
-import '../text.dart';
-import '../../utils/styles.dart';
 
 class ToggleWidgetList extends StatefulWidget {
   final List<Map<String, String>> items;
@@ -11,11 +7,11 @@ class ToggleWidgetList extends StatefulWidget {
   final bool isDisabled;
 
   const ToggleWidgetList({
-    Key? key,
+    super.key,
     required this.items,
     this.onToggle,
     this.isDisabled = false,
-  }) : super(key: key);
+  });
 
   @override
   State<ToggleWidgetList> createState() => _ToggleWidgetListState();

--- a/packages/onestop_ui/lib/components/cardcomponents/card_list.dart
+++ b/packages/onestop_ui/lib/components/cardcomponents/card_list.dart
@@ -45,7 +45,6 @@ class OListGroups extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      padding: EdgeInsets.symmetric(horizontal: OSpacing.s, vertical:OSpacing.xs),
       decoration: BoxDecoration(color: Colors.transparent),
       child: ListView.builder(
         shrinkWrap: true,

--- a/packages/onestop_ui/lib/components/cardcomponents/header.dart
+++ b/packages/onestop_ui/lib/components/cardcomponents/header.dart
@@ -20,10 +20,6 @@ class OCardHeader extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      padding: EdgeInsets.symmetric(
-        horizontal: OSpacing.s,
-        vertical: OSpacing.xxs,
-      ),
       color: Colors.transparent,
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.center,

--- a/packages/onestop_ui/lib/components/cardcomponents/label.dart
+++ b/packages/onestop_ui/lib/components/cardcomponents/label.dart
@@ -55,31 +55,25 @@ class OLabelGroups extends StatelessWidget {
         width: double.minPositive,
       ); // Return nothing if the list is empty
     }
-    return Padding(
-      padding: const EdgeInsets.symmetric(
-        horizontal: OSpacing.s,
-        vertical: OSpacing.xxs,
-      ),
-      child: Wrap(
-        // Controls the vertical gap between lines
-        runSpacing: OSpacing.xs,
-        alignment: WrapAlignment.spaceBetween,
-        crossAxisAlignment: WrapCrossAlignment.center,
-        children: [
-          for (int i = 0; i < labelItems.length; i++) ...[
-            OText(
-              text: isSmall ? labelItems[i].toUpperCase() : labelItems[i],
-              style:
-                  isSmall
-                      ? OTextStyle.labelXSmall.copyWith(color: OColor.gray600)
-                      : OTextStyle.labelSmall.copyWith(color: OColor.gray600),
-            ),
-            if (i < labelItems.length - 1) ...{
-              Icon(TablerIcons.point_filled, size: 4, color: OColor.gray600),
-            },
-          ],
+    return Wrap(
+      // Controls the vertical gap between lines
+      runSpacing: OSpacing.xs,
+      alignment: WrapAlignment.spaceBetween,
+      crossAxisAlignment: WrapCrossAlignment.center,
+      children: [
+        for (int i = 0; i < labelItems.length; i++) ...[
+          OText(
+            text: isSmall ? labelItems[i].toUpperCase() : labelItems[i],
+            style:
+                isSmall
+                    ? OTextStyle.labelXSmall.copyWith(color: OColor.gray600)
+                    : OTextStyle.labelSmall.copyWith(color: OColor.gray600),
+          ),
+          if (i < labelItems.length - 1) ...{
+            Icon(TablerIcons.point_filled, size: 4, color: OColor.gray600),
+          },
         ],
-      ),
+      ],
     );
   }
 }

--- a/packages/onestop_ui/lib/components/cardcomponents/travel_switch.dart
+++ b/packages/onestop_ui/lib/components/cardcomponents/travel_switch.dart
@@ -1,0 +1,171 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_tabler_icons/flutter_tabler_icons.dart';
+import 'package:onestop_ui/index.dart';
+
+class OTravelSwitch extends StatefulWidget {
+  final bool isEnabled;
+  final String? origin;
+  final String? destination;
+  final String originStop;
+  final String destinationStop;
+  final bool isOriginIitg;
+  final Function(bool isOriginIitg, String originStop, String destinationStop)?
+  onSwap;
+
+  const OTravelSwitch({
+    super.key,
+    required this.isEnabled,
+    this.origin,
+    this.destination,
+    required this.originStop,
+    required this.destinationStop,
+    required this.isOriginIitg,
+    this.onSwap,
+  });
+
+  @override
+  State<OTravelSwitch> createState() => _OTravelSwitchState();
+}
+
+class _OTravelSwitchState extends State<OTravelSwitch> {
+  bool _isPressed = false;
+  bool _isOriginIitg = false;
+  String _originStop = '';
+  String _destinationStop = '';
+
+  @override
+  void initState() {
+    super.initState();
+    _isOriginIitg = widget.isOriginIitg;
+    _originStop = widget.originStop;
+    _destinationStop = widget.destinationStop;
+  }
+
+  @override
+  void didUpdateWidget(OTravelSwitch oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.isOriginIitg != widget.isOriginIitg ||
+        oldWidget.originStop != widget.originStop ||
+        oldWidget.destinationStop != widget.destinationStop) {
+      setState(() {
+        _isOriginIitg = widget.isOriginIitg;
+        _originStop = widget.originStop;
+        _destinationStop = widget.destinationStop;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        _buildLocation(
+          isIitg: _isOriginIitg,
+          location: _isOriginIitg ? "IIT G" : widget.origin,
+          stop: _originStop,
+        ),
+        const SizedBox(width: OSpacing.s),
+        SizedBox(
+          width: 30,
+          child: Divider(color: OColor.gray400, thickness: 1),
+        ),
+        GestureDetector(
+          onTapDown: (_) {
+            if (widget.isEnabled) {
+              setState(() => _isPressed = true);
+            }
+          },
+          onTapUp: (_) {
+            setState(() => _isPressed = false);
+            _swapOriginDestination();
+          },
+          onTapCancel: () {
+            setState(
+              () => _isPressed = false,
+            ); // Resets state if gesture is cancelled
+          },
+          behavior: HitTestBehavior.opaque,
+          child: Container(
+            padding: EdgeInsets.all(OSpacing.xs),
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(OCornerRadius.l),
+              border: Border.all(color: OColor.gray300),
+              color: _isPressed ? OColor.gray200 : OColor.white,
+            ),
+            child: Row(
+              children: [
+                Icon(TablerIcons.arrows_diff, color: OColor.green600, size: 16),
+                const SizedBox(width: OSpacing.xxs),
+                OText(
+                  text: "Swap",
+                  style: OTextStyle.labelSmall.copyWith(color: OColor.green600),
+                ),
+              ],
+            ),
+          ),
+        ),
+        SizedBox(
+          width: 30,
+          child: Divider(color: OColor.gray400, thickness: 1),
+        ),
+        const SizedBox(width: OSpacing.s),
+        _buildLocation(
+          isIitg: !_isOriginIitg,
+          location: _isOriginIitg ? widget.destination : "IIT G",
+          stop: _destinationStop,
+        ),
+      ],
+    );
+  }
+
+  Widget _buildLocation({
+    required bool isIitg,
+    required String?  location,
+    required String stop,
+  }) {
+    return Column(
+      children: [
+        Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            CircleAvatar(
+              backgroundColor:
+                  isIitg
+                      ? Color.fromRGBO(111, 113, 237, 1)
+                      : Color.fromRGBO(68, 177, 165, 1),
+              radius: 12,
+              child: Icon(
+                isIitg ? TablerIcons.school : TablerIcons.train,
+                color: OColor.white,
+                size: 16,
+              ),
+            ),
+            const SizedBox(width: OSpacing.xxs),
+            OText(
+              text: location ?? " ",
+              style: OTextStyle.headingMedium.copyWith(color: OColor.gray800),
+            ),
+          ],
+        ),
+        const SizedBox(height: OSpacing.xxs),
+        OText(
+          text: stop.toUpperCase(),
+          style: OTextStyle.bodyXSmall.copyWith(color: OColor.gray600),
+        ),
+      ],
+    );
+  }
+
+  void _swapOriginDestination() {
+    setState(() {
+      _isOriginIitg = !_isOriginIitg;
+      final temp = _originStop;
+      _originStop = _destinationStop;
+      _destinationStop = temp;
+    });
+
+    // Notify parent widget if callback provided
+    widget.onSwap?.call(_isOriginIitg, _originStop, _destinationStop);
+  }
+}

--- a/packages/onestop_ui/lib/components/cards/food_outlet_card.dart
+++ b/packages/onestop_ui/lib/components/cards/food_outlet_card.dart
@@ -43,7 +43,7 @@ class _FoodOutletCardState extends State<FoodOutletCard> {
   @override
   Widget build(BuildContext context) {
     return Padding(
-      padding: const EdgeInsets.all(OSpacing.xs),
+      padding: const EdgeInsets.all(OSpacing.xxs),
       child: Stack(
         children: [
           GestureDetector(
@@ -57,6 +57,7 @@ class _FoodOutletCardState extends State<FoodOutletCard> {
               setState(() => _isPressed = false);
             },
             child: Container(
+              padding: const EdgeInsets.all(OSpacing.s),
               decoration: BoxDecoration(
                 color: _isPressed ? OColor.gray200 : OColor.white,
                 borderRadius: BorderRadius.all(
@@ -67,57 +68,52 @@ class _FoodOutletCardState extends State<FoodOutletCard> {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Padding(
-                    padding: const EdgeInsets.symmetric(
-                      horizontal: OSpacing.xs,
-                      vertical: OSpacing.m,
-                    ),
-                    child: Row(
-                      children: [
-                        Container(
-                          width: 48,
-                          height: 48,
-                          decoration: BoxDecoration(
-                            color: OColor.gray400,
-                            image: DecorationImage(
-                              image: NetworkImage(widget.imageUrl),
-                              fit: BoxFit.cover,
-                              opacity: widget.isEnabled ? 1 : 0.2,
+                  Row(
+                    children: [
+                      Container(
+                        width: 48,
+                        height: 48,
+                        decoration: BoxDecoration(
+                          color: OColor.gray400,
+                          image: DecorationImage(
+                            image: NetworkImage(widget.imageUrl),
+                            fit: BoxFit.cover,
+                            opacity: widget.isEnabled ? 1 : 0.2,
+                          ),
+                        ),
+                      ),
+                      Padding(
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: OSpacing.s,
+                        ),
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            OText(
+                              text: widget.heading,
+                              style: OTextStyle.labelMedium.copyWith(
+                                color:
+                                    widget.isEnabled
+                                        ? OColor.gray800
+                                        : OColor.gray600,
+                              ),
                             ),
-                          ),
-                        ),
-                        Padding(
-                          padding: const EdgeInsets.symmetric(
-                            horizontal: OSpacing.s,
-                          ),
-                          child: Column(
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: [
-                              OText(
-                                text: widget.heading,
-                                style: OTextStyle.labelMedium.copyWith(
-                                  color:
-                                      widget.isEnabled
-                                          ? OColor.gray800
-                                          : OColor.gray600,
-                                ),
+                            const SizedBox(height: OSpacing.xxs),
+                            OText(
+                              text: widget.subHeading,
+                              style: OTextStyle.bodySmall.copyWith(
+                                color:
+                                    widget.isEnabled
+                                        ? OColor.gray800
+                                        : OColor.gray300,
                               ),
-                              const SizedBox(height: OSpacing.xxs),
-                              OText(
-                                text: widget.subHeading,
-                                style: OTextStyle.bodySmall.copyWith(
-                                  color:
-                                      widget.isEnabled
-                                          ? OColor.gray800
-                                          : OColor.gray300,
-                                ),
-                              ),
-                            ],
-                          ),
+                            ),
+                          ],
                         ),
-                      ],
-                    ),
+                      ),
+                    ],
                   ),
+                  const SizedBox(height: OSpacing.m,),
                   if (widget.tag != null)
                     OTag(
                       type: widget.isEnabled?TagType.accentColor:TagType.neutral,
@@ -125,29 +121,25 @@ class _FoodOutletCardState extends State<FoodOutletCard> {
                       label: widget.tag!,
                       trail: TablerIcons.arrow_rotary_first_left,
                     ),
-                  Padding(
-                    padding: const EdgeInsets.only(top: OSpacing.xs),
-                    child: OCardLabels(
-                      label: widget.subLabelText1,
-                      icon: widget.subLabelIcon1,
-                      color: widget.isEnabled ? OColor.gray600 : OColor.gray300,
-                    ),
+                  const SizedBox(height: OSpacing.m,),
+                  OCardLabels(
+                    label: widget.subLabelText1,
+                    icon: widget.subLabelIcon1,
+                    color: widget.isEnabled ? OColor.gray600 : OColor.gray300,
                   ),
-                  Padding(
-                    padding: const EdgeInsets.only(bottom: OSpacing.s),
-                    child: OCardLabels(
-                      label: widget.subLabelText2,
-                      icon: widget.subLabelIcon2,
-                      color: widget.isEnabled ? OColor.gray600 : OColor.gray300,
-                    ),
+                  const SizedBox(height: OSpacing.xxs,),
+                  OCardLabels(
+                    label: widget.subLabelText2,
+                    icon: widget.subLabelIcon2,
+                    color: widget.isEnabled ? OColor.gray600 : OColor.gray300,
                   ),
                 ],
               ),
             ),
           ),
           Positioned(
-            top: 16,
-            right: 10,
+            top: 12,
+            right: 0,
             child: IconButton(
               icon: Icon(
                 TablerIcons.chevron_right,

--- a/packages/onestop_ui/lib/components/cards/homecard.dart
+++ b/packages/onestop_ui/lib/components/cards/homecard.dart
@@ -43,6 +43,7 @@ class _OHomeCardState extends State<OHomeCard> {
   @override
   Widget build(BuildContext context) {
     return Container(
+      padding: const EdgeInsets.all(OSpacing.s),
       decoration: BoxDecoration(
         color: _isPressed ? OColor.gray200 : OColor.white,
         borderRadius: BorderRadius.all(Radius.circular(OCornerRadius.l)),
@@ -55,6 +56,7 @@ class _OHomeCardState extends State<OHomeCard> {
             icon: TablerIcons.arrow_rotary_first_left,
             onArrowPressed: widget.onArrowPressed,
           ),
+          const SizedBox(height: OSpacing.l),
           GestureDetector(
             behavior: HitTestBehavior.opaque,
             onTapDown:
@@ -68,6 +70,7 @@ class _OHomeCardState extends State<OHomeCard> {
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 OLabelGroups(labelItems: widget.labelItems, isSmall: true),
+                const SizedBox(height: OSpacing.xxs),
                 OListGroups(
                   list: widget.listItems,
                   sublist: widget.subListItems,
@@ -81,40 +84,38 @@ class _OHomeCardState extends State<OHomeCard> {
               crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [
                 if (widget.activateButton1 == true)
-                  Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: OSpacing.s),
-                    child: MaterialButton(
-                      onPressed: widget.buttonAction1,
-                      shape: RoundedRectangleBorder(
-                        side: BorderSide(color: OColor.gray300, width: 1),
-                        borderRadius: BorderRadius.all(
-                          Radius.circular(OCornerRadius.l),
-                        ),
+                  const SizedBox(height: OSpacing.xxs),
+                if (widget.activateButton1 == true)
+                  MaterialButton(
+                    onPressed: widget.buttonAction1,
+                    shape: RoundedRectangleBorder(
+                      side: BorderSide(color: OColor.gray300, width: 1),
+                      borderRadius: BorderRadius.all(
+                        Radius.circular(OCornerRadius.l),
                       ),
-                      child: OText(
-                        text: 'Label 1',
-                        style: OTextStyle.labelSmall.copyWith(
-                          color: OColor.green600,
-                        ),
+                    ),
+                    child: OText(
+                      text: 'Label 1',
+                      style: OTextStyle.labelSmall.copyWith(
+                        color: OColor.green600,
                       ),
                     ),
                   ),
                 if (widget.activateButton2 == true)
-                  Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: OSpacing.s),
-                    child: MaterialButton(
-                      onPressed: widget.buttonAction2,
-                      shape: RoundedRectangleBorder(
-                        side: BorderSide(color: OColor.gray300, width: 1),
-                        borderRadius: BorderRadius.all(
-                          Radius.circular(OCornerRadius.l),
-                        ),
+                  const SizedBox(height: OSpacing.xxs),
+                if (widget.activateButton2 == true)
+                  MaterialButton(
+                    onPressed: widget.buttonAction2,
+                    shape: RoundedRectangleBorder(
+                      side: BorderSide(color: OColor.gray300, width: 1),
+                      borderRadius: BorderRadius.all(
+                        Radius.circular(OCornerRadius.l),
                       ),
-                      child: OText(
-                        text: 'Label 2',
-                        style: OTextStyle.labelSmall.copyWith(
-                          color: OColor.green600,
-                        ),
+                    ),
+                    child: OText(
+                      text: 'Label 2',
+                      style: OTextStyle.labelSmall.copyWith(
+                        color: OColor.green600,
                       ),
                     ),
                   ),
@@ -171,109 +172,74 @@ class _OHomeCardLargeState extends State<OHomeCardLarge> {
   @override
   Widget build(BuildContext context) {
     return Padding(
-      padding: const EdgeInsets.all(OSpacing.xs),
-      child: Stack(
-        children: [
-          GestureDetector(
-            behavior: HitTestBehavior.opaque,
-            onTapDown:
-                (_) => setState(
-                  () => _isPressed = true,
-                ), //engage behaviour when search bar is tapped
-            onTapUp: (_) {
-              setState(() => _isPressed = false);
-            },
-            child: Container(
-              padding: const EdgeInsets.symmetric(
-                horizontal: OSpacing.xxs,
-                vertical: OSpacing.s,
+      padding: const EdgeInsets.all(OSpacing.xxs),
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTapDown:
+            (_) => setState(
+              () => _isPressed = true,
+            ), //engage behaviour when search bar is tapped
+        onTapUp: (_) {
+          setState(() => _isPressed = false);
+        },
+        child: Container(
+          padding: const EdgeInsets.all(OSpacing.s),
+          decoration: BoxDecoration(
+            color: _isPressed ? OColor.gray200 : OColor.white,
+            borderRadius: BorderRadius.all(Radius.circular(OCornerRadius.l)),
+            border: Border.all(color: OColor.gray200, width: 1),
+          ),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              OCardHeader(
+                heading: widget.heading,
+                subheading: widget.subheading,
+                icon: widget.icon,
+                onClickArrow: true,
+                onArrowPressed: widget.onArrowPressed,
               ),
-              decoration: BoxDecoration(
-                color: _isPressed ? OColor.gray200 : OColor.white,
-                borderRadius: BorderRadius.all(
-                  Radius.circular(OCornerRadius.l),
+              const SizedBox(height: OSpacing.m),
+              OText(
+                text: widget.mainText,
+                style: OTextStyle.headingLarge.copyWith(color: OColor.gray800),
+              ),
+              const SizedBox(height: OSpacing.xxs),
+              OText(
+                text: widget.cardSubText,
+                style: OTextStyle.bodySmall.copyWith(color: OColor.gray600),
+              ),
+              const SizedBox(height: OSpacing.m),
+              ConstrainedBox(
+                constraints: BoxConstraints(maxHeight: widget.blockHeight),
+                child: CarouselView(
+                  enableSplash: false,
+                  itemExtent: widget.blockWidth,
+                  shrinkExtent: widget.blockWidth,
+                  scrollDirection: Axis.horizontal,
+                  itemSnapping: true,
+                  padding: const EdgeInsets.only(
+                    right: OSpacing.xxs,
+                    top: OSpacing.xs,
+                    bottom: OSpacing.xs,
+                  ),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(OCornerRadius.s),
+                  ),
+                  children:
+                      widget.dataMap.entries.map((entry) {
+                        return OCardBlock(
+                          header: entry.key,
+                          blockItems: entry.value,
+                          color: OColor.gray100,
+                        );
+                      }).toList(),
                 ),
-                border: Border.all(color: OColor.gray200, width: 1),
               ),
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  OCardHeader(
-                    heading: widget.heading,
-                    subheading: widget.subheading,
-                    icon: widget.icon,
-                    onClickArrow: false,
-                  ),
-                  Padding(
-                    padding: const EdgeInsets.symmetric(
-                      horizontal: OSpacing.s,
-                      vertical: OSpacing.xs,
-                    ),
-                    child: OText(
-                      text: widget.mainText,
-                      style: OTextStyle.headingLarge.copyWith(
-                        color: OColor.gray800,
-                      ),
-                    ),
-                  ),
-                  Padding(
-                    padding: const EdgeInsets.symmetric(
-                      horizontal: OSpacing.s,
-                      vertical: OSpacing.xxs,
-                    ),
-                    child: OText(
-                      text: widget.cardSubText,
-                      style: OTextStyle.bodySmall.copyWith(
-                        color: OColor.gray600,
-                      ),
-                    ),
-                  ),
-                  Padding(
-                    padding: const EdgeInsets.only(left: OSpacing.xs),
-                    child: ConstrainedBox(
-                      constraints: BoxConstraints(
-                        maxHeight: widget.blockHeight,
-                      ),
-                      child: CarouselView(
-                        enableSplash: false,
-                        itemExtent: widget.blockWidth,
-                        shrinkExtent: widget.blockWidth,
-                        scrollDirection: Axis.horizontal,
-                        itemSnapping: true,
-                        padding: const EdgeInsets.only(
-                          left: OSpacing.xxs,
-                          top: OSpacing.xs,
-                          bottom: OSpacing.xs,
-                        ),
-                        shape: RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(OCornerRadius.s),
-                        ),
-                        children:
-                            widget.dataMap.entries.map((entry) {
-                              return OCardBlock(
-                                  header: entry.key,
-                                  blockItems: entry.value,
-                                  color: OColor.gray100,
-                                );
-                            }).toList(),
-                      ),
-                    ),
-                  ),
-                ],
-              ),
-            ),
+            ],
           ),
-          Positioned(
-            top: 10,
-            right: 10,
-            child: IconButton(
-              icon: Icon(TablerIcons.chevron_right, color: OColor.gray600),
-              onPressed: widget.onArrowPressed,
-              iconSize: 24,
-            ),
-          ),
-        ],
+        ),
       ),
     );
   }

--- a/packages/onestop_ui/lib/components/cards/messcard.dart
+++ b/packages/onestop_ui/lib/components/cards/messcard.dart
@@ -35,7 +35,7 @@ class OMessMenuCard extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Padding(
-            padding: const EdgeInsets.only(top: OSpacing.s),
+            padding: const EdgeInsets.all(OSpacing.s),
             child: Row(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [

--- a/packages/onestop_ui/lib/components/cards/travel_card.dart
+++ b/packages/onestop_ui/lib/components/cards/travel_card.dart
@@ -4,22 +4,20 @@ import 'package:onestop_ui/index.dart';
 
 class OTravelCard extends StatefulWidget {
   final Function()? onArrowPressed;
-  final String mainText;
-  final String? cardSubText;
-  final Map<String, List<String>> dataMap;
-  final double blockHeight;
-  final double blockWidth;
+  final Map<String, int> ferryToCity;
+  final Map<String, int> ferryFromCity;
+  final Map<String, int> busToCity;
+  final Map<String, int> busFromCity;
   final bool isFerry;
   final bool isEnabled;
 
   const OTravelCard({
     super.key,
     this.onArrowPressed,
-    required this.dataMap,
-    required this.mainText,
-    this.blockWidth = 150,
-    this.blockHeight = 150,
-    this.cardSubText,
+    required this.ferryToCity,
+    required this.ferryFromCity,
+    required this.busToCity,
+    required this.busFromCity,
     required this.isFerry,
     required this.isEnabled,
   });
@@ -38,20 +36,29 @@ class _OTravelCardState extends State<OTravelCard> {
 
   @override
   Widget build(BuildContext context) {
+    final dataToCity = widget.isFerry ? widget.ferryToCity : widget.busToCity;
+    final dataFromCity =
+        widget.isFerry ? widget.ferryFromCity : widget.busFromCity;
+
     return Padding(
       padding: const EdgeInsets.all(OSpacing.xxs),
       child: GestureDetector(
         behavior: HitTestBehavior.opaque,
-        onTapDown:
-            (_) => setState(
-              () => _isPressed = true,
-            ),
+        onTapDown: (_) {
+          if (widget.isEnabled) {
+            setState(() => _isPressed = true);
+          }
+        },
         onTapUp: (_) {
           setState(() => _isPressed = false);
         },
+        onTapCancel: () {
+          setState(
+            () => _isPressed = false,
+          ); // Resets state if gesture is cancelled
+        },
         child: Container(
-          padding: const EdgeInsets.all(OSpacing.s,
-          ),
+          padding: const EdgeInsets.all(OSpacing.s),
           decoration: BoxDecoration(
             color: _isPressed ? OColor.gray200 : OColor.white,
             borderRadius: const BorderRadius.all(
@@ -67,9 +74,9 @@ class _OTravelCardState extends State<OTravelCard> {
                 heading: widget.isFerry ? "Ferry" : "Bus",
                 icon: widget.isFerry ? TablerIcons.ship : TablerIcons.bus,
                 onClickArrow: true,
-                onArrowPressed: widget.onArrowPressed,
+                onArrowPressed: widget.isEnabled ? widget.onArrowPressed : null,
               ),
-              const SizedBox(height: OSpacing.m,),
+              const SizedBox(height: OSpacing.m),
               Row(
                 mainAxisSize: MainAxisSize.max,
                 mainAxisAlignment: MainAxisAlignment.start,
@@ -77,8 +84,7 @@ class _OTravelCardState extends State<OTravelCard> {
                   OText(
                     text: "IITG",
                     style: OTextStyle.labelMedium.copyWith(
-                      color:
-                          widget.isEnabled ? OColor.gray800 : OColor.gray600,
+                      color: widget.isEnabled ? OColor.gray800 : OColor.gray600,
                     ),
                   ),
                   Icon(
@@ -89,15 +95,16 @@ class _OTravelCardState extends State<OTravelCard> {
                   OText(
                     text: "City",
                     style: OTextStyle.labelMedium.copyWith(
-                      color:
-                          widget.isEnabled ? OColor.gray800 : OColor.gray600,
+                      color: widget.isEnabled ? OColor.gray800 : OColor.gray600,
                     ),
                   ),
                 ],
               ),
-              const SizedBox(height: OSpacing.s,),
-              Divider(color: OColor.gray200),
-              const SizedBox(height: OSpacing.s,),
+              const SizedBox(height: OSpacing.s),
+              _buildTimingsList(dataToCity),
+              const SizedBox(height: OSpacing.s),
+              Divider(color: OColor.gray200, thickness: 1),
+              const SizedBox(height: OSpacing.s),
               Row(
                 mainAxisSize: MainAxisSize.max,
                 mainAxisAlignment: MainAxisAlignment.start,
@@ -105,8 +112,7 @@ class _OTravelCardState extends State<OTravelCard> {
                   OText(
                     text: "City",
                     style: OTextStyle.labelMedium.copyWith(
-                      color:
-                          widget.isEnabled ? OColor.gray800 : OColor.gray600,
+                      color: widget.isEnabled ? OColor.gray800 : OColor.gray600,
                     ),
                   ),
                   Icon(
@@ -117,17 +123,56 @@ class _OTravelCardState extends State<OTravelCard> {
                   OText(
                     text: "IITG",
                     style: OTextStyle.labelMedium.copyWith(
-                      color:
-                          widget.isEnabled ? OColor.gray800 : OColor.gray600,
+                      color: widget.isEnabled ? OColor.gray800 : OColor.gray600,
                     ),
                   ),
                 ],
               ),
+              const SizedBox(height: OSpacing.s),
+              _buildTimingsList(dataFromCity),
             ],
           ),
         ),
       ),
     );
+  }
+
+  Widget _buildTimingsList(Map<String, int> data) {
+    return Column(
+      children:
+          data.entries.map((entry) {
+            return Padding(
+              padding: const EdgeInsets.only(bottom: OSpacing.xxs),
+              child: Row(
+                mainAxisSize: MainAxisSize.max,
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  OText(
+                    text: entry.key.toUpperCase(),
+                    style: OTextStyle.labelXSmall.copyWith(
+                      color: OColor.gray600,
+                    ),
+                  ),
+                  OText(
+                    text: "In ${entry.value} mins",
+                    style: OTextStyle.labelXSmall.copyWith(
+                      color:
+                          widget.isEnabled
+                              ? _getTimingColor(entry.value)
+                              : OColor.gray400,
+                    ),
+                  ),
+                ],
+              ),
+            );
+          }).toList(),
+    );
+  }
+
+  Color _getTimingColor(int minutes) {
+    if (minutes >= 30) return OColor.green600;
+    if (minutes >= 10) return OColor.yellow600;
+    return OColor.red500;
   }
 
   @override

--- a/packages/onestop_ui/lib/components/cards/travel_card.dart
+++ b/packages/onestop_ui/lib/components/cards/travel_card.dart
@@ -1,0 +1,137 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_tabler_icons/flutter_tabler_icons.dart';
+import 'package:onestop_ui/index.dart';
+
+class OTravelCard extends StatefulWidget {
+  final Function()? onArrowPressed;
+  final String mainText;
+  final String? cardSubText;
+  final Map<String, List<String>> dataMap;
+  final double blockHeight;
+  final double blockWidth;
+  final bool isFerry;
+  final bool isEnabled;
+
+  const OTravelCard({
+    super.key,
+    this.onArrowPressed,
+    required this.dataMap,
+    required this.mainText,
+    this.blockWidth = 150,
+    this.blockHeight = 150,
+    this.cardSubText,
+    required this.isFerry,
+    required this.isEnabled,
+  });
+
+  @override
+  State<OTravelCard> createState() => _OTravelCardState();
+}
+
+class _OTravelCardState extends State<OTravelCard> {
+  bool _isPressed = false;
+
+  @override
+  void initState() {
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(OSpacing.xxs),
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTapDown:
+            (_) => setState(
+              () => _isPressed = true,
+            ),
+        onTapUp: (_) {
+          setState(() => _isPressed = false);
+        },
+        child: Container(
+          padding: const EdgeInsets.all(OSpacing.s,
+          ),
+          decoration: BoxDecoration(
+            color: _isPressed ? OColor.gray200 : OColor.white,
+            borderRadius: const BorderRadius.all(
+              Radius.circular(OCornerRadius.l),
+            ),
+            border: Border.all(color: OColor.gray200, width: 1),
+          ),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              OCardHeader(
+                heading: widget.isFerry ? "Ferry" : "Bus",
+                icon: widget.isFerry ? TablerIcons.ship : TablerIcons.bus,
+                onClickArrow: true,
+                onArrowPressed: widget.onArrowPressed,
+              ),
+              const SizedBox(height: OSpacing.m,),
+              Row(
+                mainAxisSize: MainAxisSize.max,
+                mainAxisAlignment: MainAxisAlignment.start,
+                children: [
+                  OText(
+                    text: "IITG",
+                    style: OTextStyle.labelMedium.copyWith(
+                      color:
+                          widget.isEnabled ? OColor.gray800 : OColor.gray600,
+                    ),
+                  ),
+                  Icon(
+                    TablerIcons.arrow_narrow_right,
+                    color: OColor.gray500,
+                    size: 24,
+                  ),
+                  OText(
+                    text: "City",
+                    style: OTextStyle.labelMedium.copyWith(
+                      color:
+                          widget.isEnabled ? OColor.gray800 : OColor.gray600,
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: OSpacing.s,),
+              Divider(color: OColor.gray200),
+              const SizedBox(height: OSpacing.s,),
+              Row(
+                mainAxisSize: MainAxisSize.max,
+                mainAxisAlignment: MainAxisAlignment.start,
+                children: [
+                  OText(
+                    text: "City",
+                    style: OTextStyle.labelMedium.copyWith(
+                      color:
+                          widget.isEnabled ? OColor.gray800 : OColor.gray600,
+                    ),
+                  ),
+                  Icon(
+                    TablerIcons.arrow_narrow_right,
+                    color: OColor.gray500,
+                    size: 24,
+                  ),
+                  OText(
+                    text: "IITG",
+                    style: OTextStyle.labelMedium.copyWith(
+                      color:
+                          widget.isEnabled ? OColor.gray800 : OColor.gray600,
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+  }
+}

--- a/packages/onestop_ui/lib/components/cards/travel_suggestion_card.dart
+++ b/packages/onestop_ui/lib/components/cards/travel_suggestion_card.dart
@@ -1,0 +1,149 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_tabler_icons/flutter_tabler_icons.dart';
+import 'package:onestop_ui/index.dart';
+
+class OTravelSuggestionCard extends StatefulWidget {
+  final bool isEnabled;
+  final VoidCallback? goToGuide;
+  final String? warning;
+  final String body;
+
+  const OTravelSuggestionCard({
+    super.key,
+    required this.isEnabled,
+    this.goToGuide,
+    this.warning,
+    required this.body,
+  });
+
+  @override
+  State<OTravelSuggestionCard> createState() => _OTravelSuggestionCardState();
+}
+
+class _OTravelSuggestionCardState extends State<OTravelSuggestionCard> {
+  bool _isPressed = false;
+  bool _isExpanded = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTapDown: (_) {
+        if (widget.isEnabled) {
+          setState(() => _isPressed = true);
+        }
+      },
+      onTapUp: (_) {
+        setState(() => _isPressed = false);
+      },
+      onTapCancel: () {
+        setState(
+          () => _isPressed = false,
+        ); // Resets state if gesture is cancelled
+      },
+      child: Container(
+        padding:
+            _isExpanded
+                ? EdgeInsets.only(
+                  right: OSpacing.s,
+                  left: OSpacing.s,
+                  top: OSpacing.s,
+                )
+                : EdgeInsets.all(OSpacing.s),
+        decoration: BoxDecoration(
+          color: _isPressed ? OColor.gray200 : OColor.white,
+          borderRadius: const BorderRadius.all(
+            Radius.circular(OCornerRadius.l),
+          ),
+          border: Border.all(color: OColor.gray200, width: 1),
+        ),
+        child: Column(
+          children: [
+            OCardHeader(
+              heading: "Travel by Ferry",
+              icon: TablerIcons.ship,
+              onArrowPressed: () {
+                setState(() => _isExpanded = true);
+              },
+            ),
+            if (_isExpanded == true) const SizedBox(height: OSpacing.s),
+            if (_isExpanded == true)
+              OText(
+                text: widget.body,
+                style: OTextStyle.labelSmall.copyWith(color: OColor.gray800),
+              ),
+            if (_isExpanded == true && widget.warning != null)
+              const SizedBox(height: OSpacing.s),
+            if (_isExpanded == true && widget.warning != null)
+              Container(
+                padding: const EdgeInsets.all(OSpacing.s),
+                decoration: BoxDecoration(
+                  borderRadius: BorderRadius.circular(OCornerRadius.s),
+                  color: OColor.yellow100,
+                ),
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  mainAxisAlignment: MainAxisAlignment.start,
+                  children: [
+                    Icon(
+                      TablerIcons.alert_triangle,
+                      size: 16,
+                      color: OColor.black,
+                    ),
+                    const SizedBox(width: OSpacing.s),
+                    Expanded(
+                      child: OText(
+                        text: widget.warning,
+                        style: OTextStyle.headingXSmall.copyWith(
+                          color: OColor.black,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            if (_isExpanded == true) const SizedBox(height: OSpacing.s),
+            if (_isExpanded == true)
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Icon(TablerIcons.book, size: 16, color: OColor.green600),
+                      const SizedBox(width: OSpacing.s),
+                      OText(
+                        text: "Travel Guide",
+                        style: OTextStyle.labelSmall.copyWith(
+                          color: OColor.green600,
+                        ),
+                      ),
+                      IconButton(
+                        onPressed: widget.goToGuide,
+                        icon: Icon(
+                          TablerIcons.arrow_up_right,
+                          size: 16,
+                          color: OColor.green600,
+                        ),
+                      ),
+                    ],
+                  ),
+                  TextButton(
+                    onPressed: () {
+                      setState(() => _isExpanded = false);
+                    },
+                    child: OText(
+                      text: "Hide",
+                      style: OTextStyle.labelSmall.copyWith(
+                        color: OColor.gray600,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/packages/onestop_ui/lib/components/images/image_gallery.dart
+++ b/packages/onestop_ui/lib/components/images/image_gallery.dart
@@ -10,13 +10,13 @@ class OnestopImageGallery extends StatelessWidget {
   final BoxShape shape;
   final ImagePreviewType previewType;
   const OnestopImageGallery({
-    Key? key,
+    super.key,
     required this.imageUrls,
     this.imageSize = 100,
     this.scrollDirection = Axis.horizontal,
     this.shape = BoxShape.rectangle,
     this.previewType = ImagePreviewType.square,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -60,11 +60,11 @@ class OnestopLargeImageGallery extends StatelessWidget {
   final ImagePreviewType previewType;
 
   const OnestopLargeImageGallery({
-    Key? key,
+    super.key,
     required this.imageUrls,
     required this.previewType,
     // this.previewType = ImagePreviewType.square,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -116,11 +116,11 @@ class OnestopMediumImageGallery extends StatelessWidget {
   final ImagePreviewType previewType;
 
   const OnestopMediumImageGallery({
-    Key? key,
+    super.key,
     required this.imageUrls,
     required this.previewType,
     // this.previewType = ImagePreviewType.square,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -137,11 +137,11 @@ class SingleImageGallery extends StatelessWidget {
   final ImagePreviewType previewType;
 
   const SingleImageGallery({
-    Key? key,
+    super.key,
     required this.imageUrl,
     required this.previewType,
     // this.previewType = ImagePreviewType.square,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/packages/onestop_ui/lib/components/images/image_preview.dart
+++ b/packages/onestop_ui/lib/components/images/image_preview.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import '../../constants/corner_radius.dart';
-import '../../constants/spacing.dart';
+
 
 enum ImagePreviewType {
   square,
@@ -19,7 +19,7 @@ class OnestopImagePreview extends StatelessWidget {
   final ImagePreviewType? previewType;
   final VoidCallback? onTap;
   const OnestopImagePreview({
-    Key? key,
+    super.key,
     required this.imageUrl,
     this.height,
     this.width,
@@ -29,7 +29,7 @@ class OnestopImagePreview extends StatelessWidget {
     this.borderRadius,
     this.previewType,
     this.onTap,
-  }) : super(key: key);
+  });
 
   double getHeight() {
     if (previewType != null) {

--- a/packages/onestop_ui/lib/index.dart
+++ b/packages/onestop_ui/lib/index.dart
@@ -47,7 +47,7 @@ export 'widget_demo/buttons_demo.dart';
 export 'list/list_export.dart';
 export 'widget_demo/list_demo.dart';
 export 'store/theme_store.dart';
-export 'components/ListButtons/ToggleButton.dart';
+export 'components/ListButtons/toggle_button.dart';
 export 'widget_demo/toggle_list_demo.dart';
 
 // modals

--- a/packages/onestop_ui/lib/index.dart
+++ b/packages/onestop_ui/lib/index.dart
@@ -29,6 +29,8 @@ export 'components/cards/events_card.dart';
 export 'components/cards/lost_n_found.dart';
 export 'components/cards/buy_n_sell.dart';
 export 'components/cards/events_listing_cards.dart';
+export 'components/cards/travel_card.dart';
+export 'components/cards/travel_suggestion_card.dart';
 export 'widget_demo/cards_demo.dart';
 
 export 'buttons/button_exports.dart';

--- a/packages/onestop_ui/lib/index.dart
+++ b/packages/onestop_ui/lib/index.dart
@@ -18,6 +18,7 @@ export 'components/cardcomponents/label.dart';
 export 'components/cardcomponents/header.dart';
 export 'components/cardcomponents/card_list.dart';
 export 'components/cardcomponents/cardblock.dart';
+export 'components/cardcomponents/travel_switch.dart';
 
 //Cards
 export 'components/cards/homecard.dart';

--- a/packages/onestop_ui/lib/indicators/tag.dart
+++ b/packages/onestop_ui/lib/indicators/tag.dart
@@ -39,7 +39,6 @@ class OTag extends StatelessWidget {
   Widget build(BuildContext context) {
     return Container(
       height: 24,
-      margin: const EdgeInsets.symmetric(vertical: 4, horizontal: 8),
       decoration: BoxDecoration(
         color: backgroundColor,
         borderRadius: BorderRadius.circular(12),

--- a/packages/onestop_ui/lib/list/drop_down_tile.dart
+++ b/packages/onestop_ui/lib/list/drop_down_tile.dart
@@ -11,14 +11,14 @@ class DropDownField extends StatefulWidget {
   final ValueChanged<String?>? onChanged;
 
   const DropDownField({
-    Key? key,
+    super.key,
     required this.label,
     required this.hint,
     required this.items,
     this.value,
     this.isEnabled = true,
     this.onChanged,
-  }) : super(key: key);
+  });
 
   @override
   State<DropDownField> createState() => _DropDownFieldState();

--- a/packages/onestop_ui/lib/widget_demo/cards_demo.dart
+++ b/packages/onestop_ui/lib/widget_demo/cards_demo.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_tabler_icons/flutter_tabler_icons.dart';
+import 'package:onestop_ui/components/cards/travel_card.dart';
 import 'package:onestop_ui/index.dart';
 
 class CardsDemo extends StatelessWidget {
@@ -10,6 +11,24 @@ class CardsDemo extends StatelessWidget {
     return SizedBox(
       child: Column(
         children: [
+          OTravelCard(
+            dataMap: {
+              // this is the map of data which has to be mapped into the blocks of main home card
+              'breakfast': ['Eggs', 'Toast', 'Coffee', 'Cereal'],
+              'lunch': ['Sandwich', 'Salad', 'Soup', 'Pizza'],
+              'dinner': ['Pasta', 'Chicken', 'Rice', 'Vegetables'],
+              'snacks': ['Chips', 'Cookies', 'Fruits', 'Nuts'],
+              'beverages': ['Water', 'Juice', 'Soda', 'Tea'],
+            },
+            blockHeight:
+            140, // adjust the height  of the block containing item list
+            blockWidth:
+            150, // adjust the width of the block containing item list
+            mainText: "Main Card Information",
+            cardSubText: "Card Sub Text",
+            onArrowPressed:
+                () {}, isFerry: true, isEnabled: true,
+          ),
           OEventCardCompact(
             isEnabled: true,
             isFeedbackOn: true,

--- a/packages/onestop_ui/lib/widget_demo/cards_demo.dart
+++ b/packages/onestop_ui/lib/widget_demo/cards_demo.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_tabler_icons/flutter_tabler_icons.dart';
-import 'package:onestop_ui/components/cards/travel_card.dart';
 import 'package:onestop_ui/index.dart';
 
 class CardsDemo extends StatelessWidget {
@@ -11,6 +10,14 @@ class CardsDemo extends StatelessWidget {
     return SizedBox(
       child: Column(
         children: [
+          OTravelSuggestionCard(
+            isEnabled: true,
+            body:
+                'Flutter follows a unidirectional data flow - data flows down from parent to child through constructor parameters. When a child needs to send data back up to the parent, it uses callbacks',
+            goToGuide: () {},
+            warning:
+                "Flutter follows a unidirectional data flow - data flows down from parent to child through constructor parameters. When a child needs to send data back up to the parent, it uses callbacks",
+          ),
           OTravelSwitch(
             isEnabled: true,
             origin: 'City',

--- a/packages/onestop_ui/lib/widget_demo/cards_demo.dart
+++ b/packages/onestop_ui/lib/widget_demo/cards_demo.dart
@@ -11,23 +11,32 @@ class CardsDemo extends StatelessWidget {
     return SizedBox(
       child: Column(
         children: [
+          OTravelSwitch(
+            isEnabled: true,
+            origin: 'City',
+            destination: 'City',
+            originStop: 'Nehru Park',
+            destinationStop: 'Biotech',
+            isOriginIitg: false,
+            // this widget also contains an onSwap function which gives an option for what to do after swapping
+          ),
           OTravelCard(
             onArrowPressed: () {},
             isFerry: true,
             isEnabled: false,
             ferryToCity: {'breakfast': 34, 'lunch': 23, 'dinner': 6},
             ferryFromCity: {'breakfast': 34, 'lunch': 23, 'dinner': 6},
-            busToCity: {'breakfast': 34,  'dinner': 6},
-            busFromCity: {'breakfast': 34, 'lunch': 23, },
+            busToCity: {'breakfast': 34, 'dinner': 6},
+            busFromCity: {'breakfast': 34, 'lunch': 23},
           ),
           OTravelCard(
             onArrowPressed: () {},
-            isFerry:false,
+            isFerry: false,
             isEnabled: true,
             ferryToCity: {'breakfast': 34, 'lunch': 23, 'dinner': 6},
             ferryFromCity: {'breakfast': 34, 'lunch': 23, 'dinner': 6},
-            busToCity: {'breakfast': 34,  'dinner': 6},
-            busFromCity: {'breakfast': 34, 'lunch': 23, },
+            busToCity: {'breakfast': 34, 'dinner': 6},
+            busFromCity: {'breakfast': 34, 'lunch': 23},
           ),
           OTravelCard(
             onArrowPressed: () {},
@@ -35,8 +44,8 @@ class CardsDemo extends StatelessWidget {
             isEnabled: true,
             ferryToCity: {'breakfast': 34, 'lunch': 23, 'dinner': 6},
             ferryFromCity: {'breakfast': 34, 'lunch': 23, 'dinner': 6},
-            busToCity: {'breakfast': 34,  'dinner': 6},
-            busFromCity: {'breakfast': 34, 'lunch': 23, },
+            busToCity: {'breakfast': 34, 'dinner': 6},
+            busFromCity: {'breakfast': 34, 'lunch': 23},
           ),
           OEventCardCompact(
             isEnabled: true,

--- a/packages/onestop_ui/lib/widget_demo/cards_demo.dart
+++ b/packages/onestop_ui/lib/widget_demo/cards_demo.dart
@@ -12,22 +12,31 @@ class CardsDemo extends StatelessWidget {
       child: Column(
         children: [
           OTravelCard(
-            dataMap: {
-              // this is the map of data which has to be mapped into the blocks of main home card
-              'breakfast': ['Eggs', 'Toast', 'Coffee', 'Cereal'],
-              'lunch': ['Sandwich', 'Salad', 'Soup', 'Pizza'],
-              'dinner': ['Pasta', 'Chicken', 'Rice', 'Vegetables'],
-              'snacks': ['Chips', 'Cookies', 'Fruits', 'Nuts'],
-              'beverages': ['Water', 'Juice', 'Soda', 'Tea'],
-            },
-            blockHeight:
-            140, // adjust the height  of the block containing item list
-            blockWidth:
-            150, // adjust the width of the block containing item list
-            mainText: "Main Card Information",
-            cardSubText: "Card Sub Text",
-            onArrowPressed:
-                () {}, isFerry: true, isEnabled: true,
+            onArrowPressed: () {},
+            isFerry: true,
+            isEnabled: false,
+            ferryToCity: {'breakfast': 34, 'lunch': 23, 'dinner': 6},
+            ferryFromCity: {'breakfast': 34, 'lunch': 23, 'dinner': 6},
+            busToCity: {'breakfast': 34,  'dinner': 6},
+            busFromCity: {'breakfast': 34, 'lunch': 23, },
+          ),
+          OTravelCard(
+            onArrowPressed: () {},
+            isFerry:false,
+            isEnabled: true,
+            ferryToCity: {'breakfast': 34, 'lunch': 23, 'dinner': 6},
+            ferryFromCity: {'breakfast': 34, 'lunch': 23, 'dinner': 6},
+            busToCity: {'breakfast': 34,  'dinner': 6},
+            busFromCity: {'breakfast': 34, 'lunch': 23, },
+          ),
+          OTravelCard(
+            onArrowPressed: () {},
+            isFerry: true,
+            isEnabled: true,
+            ferryToCity: {'breakfast': 34, 'lunch': 23, 'dinner': 6},
+            ferryFromCity: {'breakfast': 34, 'lunch': 23, 'dinner': 6},
+            busToCity: {'breakfast': 34,  'dinner': 6},
+            busFromCity: {'breakfast': 34, 'lunch': 23, },
           ),
           OEventCardCompact(
             isEnabled: true,

--- a/packages/onestop_ui/lib/widget_demo/dates.dart
+++ b/packages/onestop_ui/lib/widget_demo/dates.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
-import '../utils/styles.dart';
 import '../utils/colors.dart';
+import '../utils/styles.dart';
 import 'package:intl/intl.dart';
 import '../constants/spacing.dart';
 

--- a/packages/onestop_ui/lib/widget_demo/toggle_list_demo.dart
+++ b/packages/onestop_ui/lib/widget_demo/toggle_list_demo.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:onestop_ui/constants/spacing.dart';
 import 'package:onestop_ui/store/theme_store.dart';
-import '../components/ListButtons/ToggleButton.dart';
+import '../components/ListButtons/toggle_button.dart';
 
 class ToggleDemo extends StatelessWidget {
   const ToggleDemo({super.key});

--- a/packages/onestop_ui/pubspec.yaml
+++ b/packages/onestop_ui/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   get_storage: ^2.1.1
   animated_custom_dropdown: 3.1.1
   flutter_tabler_icons: ^1.43.0
-  intl: ^0.19.0
+  intl: ^0.20.2
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -116,13 +116,13 @@ packages:
     source: hosted
     version: "2.1.1"
   intl:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: intl
-      sha256: d6f56758b7d3014a48af9701c085700aac781a92a87a62b1333b46d8879661cf
+      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
       url: "https://pub.dev"
     source: hosted
-    version: "0.19.0"
+    version: "0.20.2"
   leak_tracker:
     dependency: transitive
     description:
@@ -258,14 +258,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.8"
-  simple_gesture_detector:
-    dependency: transitive
-    description:
-      name: simple_gesture_detector
-      sha256: ba2cd5af24ff20a0b8d609cec3f40e5b0744d2a71804a2616ae086b9c19d19a3
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.2.1"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -303,14 +295,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.1"
-  table_calendar:
-    dependency: transitive
-    description:
-      name: table_calendar
-      sha256: b2896b7c86adf3a4d9c911d860120fe3dbe03c85db43b22fd61f14ee78cdbb63
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.1.3"
   term_glyph:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,6 +38,7 @@ dependencies:
     path: packages/onestop_ui
   get_storage: ^2.1.1
   flutter_tabler_icons: ^1.43.0
+  intl: ^0.20.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## **User description**
following cards are added -
1. OTravelCard
2. OTravelSuggestionCard

and  a OTravelSwitch which can swap the origin and destination upon click


___

## **CodeAnt-AI Description**
**Add travel cards, swap control, and update card spacing and demos**

### What Changed
- New travel UI: OTravelCard shows "IITG ⇢ City" and "City ⇢ IITG" sections with arrival times and colored timing indicators (red/yellow/green) and an optional arrow to open details.
- New interactive controls: OTravelSwitch lets users swap origin and destination (including associated stop labels) and emits a callback on swap; OTravelSuggestionCard is an expandable suggestion card with optional warning box and a "Travel Guide" link.
- Library exports and demos updated so the new travel widgets appear in the demo app and are available from the package entrypoint.
- Visual refinements across cards and tags: adjusted paddings, removed extra tag margins, added consistent spacing between elements, and repositioned the chevron on FoodOutletCard for tighter, more consistent card layouts.
- README and package configuration updated (intl bumped) to document and support the new components.

### Impact
`✅ Swap origin/destination in travel views`
`✅ Clearer arrival times with color-coded urgency`
`✅ Consistent card spacing in demos and consumer apps`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
